### PR TITLE
configurable verbosity

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:          2.2
 Name:                   hie-bios
-Version:                0.7.1
+Version:                0.7.2
 Author:                 Matthew Pickering <matthewtpickering@gmail.com>
 Maintainer:             Matthew Pickering <matthewtpickering@gmail.com>
 License:                BSD-3-Clause

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -13,6 +13,7 @@ data BIOSVerbosity = Silent | Verbose
 
 data CradleOpts = CradleOpts
                 { cradleOptsVerbosity :: BIOSVerbosity
+                -- ^ unused so far
                 , cradleOptsHandle :: Maybe Handle
                 -- ^ The handle where to send output to, if not set, stderr.
                 }


### PR DESCRIPTION
some of the changes are just recommandations made by haskell-language-server, I saw it fit to make hie-bios follows the recommandation from the software it exists for.

I would like to make this change configurable on the CLI rather than hardcode it
https://github.com/mpickering/hie-bios/compare/master...teto:nix?expand=1#diff-268e4205229d03a6419924ecdf57a963794db10db21703878f4d22424f2c8b58R47  
Do you think its a good idea ? or maybe we could just remove the
`setVerbosity 0                       -- Set verbosity to zero just in case the user specified `-vx` in the options.` ?
The user can set -v0 himself ? and is there any reason not to show a detailed log in the first place ?