### PR TITLE
Use the proper GHC version given by cabal

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -1,7 +1,8 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE BangPatterns #-}
 module HIE.Bios.Cradle (
       findCradle
     , loadCradle
@@ -22,45 +23,47 @@ module HIE.Bios.Cradle (
     , makeCradleResult
   ) where
 
+import Control.Applicative ((<|>), optional)
+import Data.Bifunctor (first)
+import Control.DeepSeq
 import Control.Exception (handleJust)
 import qualified Data.Yaml as Yaml
 import Data.Void
 import Data.Char (isSpace)
-import Data.Bifunctor (first)
-import System.Process
 import System.Exit
-import HIE.Bios.Types hiding (ActionName(..))
-import qualified HIE.Bios.Types as Types
-import HIE.Bios.Config
-import HIE.Bios.Environment (getCacheDir)
-import qualified HIE.Bios.Ghc.Gap as Gap
 import System.Directory hiding (findFile)
+import Control.Monad
+import Control.Monad.Extra (unlessM)
 import Control.Monad.Trans.Cont
 import Control.Monad.Trans.Maybe
-import System.FilePath
-import Control.Monad
-import System.Info.Extra
 import Control.Monad.IO.Class
-import System.Environment
-import Control.Applicative ((<|>), optional)
-import System.IO.Temp
-import System.IO.Error (isPermissionError)
-import Data.List
-import Data.Ord (Down(..))
-
-import System.PosixCompat.Files
-import HIE.Bios.Wrappers
-import System.IO
-import Control.DeepSeq
-
 import Data.Conduit.Process
 import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Text as C
-import qualified Data.Text as T
 import qualified Data.HashMap.Strict as Map
-import           Data.Maybe (fromMaybe, maybeToList)
-import           GHC.Fingerprint (fingerprintString)
+import Data.Maybe (fromMaybe, maybeToList)
+import Data.List
+import Data.List.Extra (trimEnd)
+import Data.Ord (Down(..))
+import qualified Data.Text as T
+import System.Environment
+import System.FilePath
+import System.PosixCompat.Files
+import System.Info.Extra (isWindows)
+import System.IO (hClose, hGetContents, hSetBuffering, BufferMode(LineBuffering), withFile, IOMode(..))
+import System.IO.Error (isPermissionError)
+import System.IO.Temp
+
+import HIE.Bios.Config
+import HIE.Bios.Environment (getCacheDir)
+import HIE.Bios.Types hiding (ActionName(..))
+import HIE.Bios.Wrappers
+import qualified HIE.Bios.Types as Types
+import qualified HIE.Bios.Ghc.Gap as Gap
+
+import GHC.Fingerprint (fingerprintString)
+import GHC.ResponseFile (escapeArgs)
 
 hie_bios_output :: String
 hie_bios_output = "HIE_BIOS_OUTPUT"
@@ -98,7 +101,7 @@ getCradle :: (b -> Cradle a) -> (CradleConfig b, FilePath) -> Cradle a
 getCradle buildCustomCradle (cc, wdir) = addCradleDeps cradleDeps $ case cradleType cc of
     Cabal CabalType{ cabalComponent = mc } -> cabalCradle wdir mc
     CabalMulti dc ms ->
-      getCradle buildCustomCradle $
+      getCradle buildCustomCradle
         (CradleConfig cradleDeps
           (Multi [(p, CradleConfig [] (Cabal $ dc <> c)) | (p, c) <- ms])
         , wdir)
@@ -108,7 +111,7 @@ getCradle buildCustomCradle (cc, wdir) = addCradleDeps cradleDeps $ case cradleT
       in
         stackCradle wdir mc stackYamlConfig
     StackMulti ds ms ->
-      getCradle buildCustomCradle $
+      getCradle buildCustomCradle
         (CradleConfig cradleDeps
           (Multi [(p, CradleConfig [] (Stack $ ds <> c)) | (p, c) <- ms])
         , wdir)
@@ -334,7 +337,7 @@ multiAction buildCustomCradle cur_dir cs l cur_fp =
     canonicalizeCradles :: IO [(FilePath, CradleConfig b)]
     canonicalizeCradles =
       sortOn (Down . fst)
-        <$> mapM (\(p, c) -> (,c) <$> (makeAbsolute (cur_dir </> p))) cs
+        <$> mapM (\(p, c) -> (,c) <$> makeAbsolute (cur_dir </> p)) cs
 
     selectCradle [] =
       return (CradleFail (CradleError [] ExitSuccess err_msg))
@@ -412,7 +415,7 @@ biosAction wdir bios bios_deps l fp = do
 callableToProcess :: Callable -> Maybe String -> IO CreateProcess
 callableToProcess (Command shellCommand) file = do
   old_env <- getEnvironment
-  return $ (shell shellCommand) { env = (: old_env) <$> (,) hieBiosArg <$> file }
+  return $ (shell shellCommand) { env = (: old_env) . (,) hieBiosArg <$> file }
     where
       hieBiosArg = "HIE_BIOS_ARG"
 callableToProcess (Program path) file = do
@@ -435,11 +438,112 @@ cabalCradle wdir mc =
             -- ./dist-newstyle/tmp/environment.-24811: createDirectory: does not exist (No such file or directory)
             createDirectoryIfMissing True (buildDir </> "tmp")
             -- Need to pass -v0 otherwise we get "resolving dependencies..."
-            wrapper_fp <- withCabalWrapperTool ("ghc", []) wdir
-            readProcessWithCwd
-              wdir "cabal" (["--builddir="<>buildDir,"v2-exec","--with-compiler", wrapper_fp, "ghc", "-v0", "--"] ++ args) ""
+            cabalProcLoadResult <- cabalProcess wdir "v2-exec" $ ["ghc", "-v0", "--"] ++ args
+            cabalProcLoadResult `bindIO` \cabalProc ->
+              readProcessWithCwd' cabalProc ""
         }
     }
+
+-- | Execute a cabal process in our custom cache-build directory configured
+-- with the custom ghc executable.
+-- The created process has its working directory set to the given working directory.
+--
+-- Invokes the cabal process in the given directory.
+-- Finds the appropriate @ghc@ version as a fallback and provides the path
+-- to the custom ghc wrapper via 'HIE_BIOS_GHC' environment variable which
+-- the custom ghc wrapper may use as a fallback if it can not respond to certain
+-- queries, such as ghc version or location of the libdir.
+cabalProcess :: FilePath -> String -> [String] -> IO (CradleLoadResult CreateProcess)
+cabalProcess workDir command args = do
+  ghcDirLoadResult <- cabalGhcDirs workDir
+  ghcDirLoadResult `bindIO` \ghcDirs -> do
+    newEnvironment <- setupEnvironment ghcDirs
+    cabalProc <- setupCabalCommand ghcDirs
+    pure $ CradleSuccess (cabalProc
+        { env = Just newEnvironment
+        , cwd = Just workDir
+        })
+  where
+    processEnvironment :: (FilePath, FilePath) -> [(String, String)]
+    processEnvironment (ghcBin, libdir) =
+      [("HIE_BIOS_GHC", ghcBin), ("HIE_BIOS_GHC_ARGS",  "-B" ++ libdir)]
+
+    setupEnvironment :: (FilePath, FilePath) -> IO [(String, String)]
+    setupEnvironment ghcDirs = do
+      environment <- getCleanEnvironment
+      pure $ processEnvironment ghcDirs ++ environment
+
+    setupCabalCommand :: (FilePath, FilePath) -> IO CreateProcess
+    setupCabalCommand (ghcBin, libdir) = do
+      wrapper_fp <- withGhcWrapperTool ("ghc", []) workDir
+      buildDir <- cabalBuildDir workDir
+      ghcPkgPath <- withGhcPkgTool ghcBin libdir
+      let extraCabalArgs =
+            [ "--builddir=" <> buildDir
+            , command
+            , "--with-compiler", wrapper_fp
+            , "--with-hc-pkg", ghcPkgPath
+            ]
+      pure $ proc "cabal" (extraCabalArgs ++ args)
+
+-- | Discovers the location of 'ghc-pkg' given the absolute path to 'ghc'
+-- and its '$libdir' (obtainable by running @ghc --print-libdir@).
+--
+-- @'withGhcPkgTool' ghcPathAbs libdir@ guesses the location by looking at
+-- the filename of 'ghcPathAbs' and expects that 'ghc-pkg' is right next to it,
+-- which is guaranteed by the ghc build system. Most OS's follow this
+-- convention.
+--
+-- On unix, there is a high-chance that the obtained 'ghc' location is the
+-- "unwrapped" executable, e.g. the executable without a shim that specifies
+-- the '$libdir' and other important constants.
+-- As such, the executable 'ghc-pkg' is similarly without a wrapper shim and
+-- is lacking certain constants such as 'global-package-db'. It is, therefore,
+-- not suitable to pass in to other consumers, such as 'cabal'.
+--
+-- Here, we restore the wrapper-shims, if necessary, thus the returned filepath
+-- can be passed to 'cabal' without further modifications.
+withGhcPkgTool :: FilePath -> FilePath -> IO FilePath
+withGhcPkgTool ghcPathAbs libdir = do
+  let ghcName = takeFileName ghcPathAbs
+      -- TODO: check for existence
+      ghcPkgPath = guessGhcPkgFromGhc ghcName
+  if isWindows
+    then pure ghcPkgPath
+    else withWrapperTool ghcPkgPath
+  where
+    ghcDir = takeDirectory ghcPathAbs
+
+    guessGhcPkgFromGhc ghcName =
+      let ghcPkgName = T.replace "ghc" "ghc-pkg" (T.pack ghcName)
+      in ghcDir </> T.unpack ghcPkgName
+
+    -- Only on unix, creates a wrapper script that's hopefully identical
+    -- to the wrapper script 'ghc-pkg' usually comes with.
+    --
+    -- 'ghc-pkg' needs to know the 'global-package-db' location which is
+    -- passed in via a wrapper shim that basically wraps 'ghc-pkg' and
+    -- only passes in the correct 'global-package-db'.
+    -- For an example on how the wrapper script is supposed to look like, take
+    -- a look at @cat $(which ghc-pkg)@, assuming 'ghc-pkg' is on your $PATH.
+    --
+    -- If we used the raw executable, i.e. not wrapped in a shim, then 'cabal'
+    -- can not use the given 'ghc-pkg'.
+    withWrapperTool ghcPkg = do
+      let globalPackageDb = libdir </> "package.conf.d"
+          -- This is the same as the wrapper-shims ghc-pkg usually comes with.
+          contents = unlines
+            [ "#!/bin/sh"
+            , unwords ["exec", escapeFilePath ghcPkg
+                      , "--global-package-db", escapeFilePath globalPackageDb
+                      , "${1+\"$@\"}"
+                      ]
+            ]
+          srcHash = show (fingerprintString contents)
+      cacheFile "ghc-pkg" srcHash $ \wrapperFp -> writeFile wrapperFp contents
+
+    -- Escape the filepath and trim excess newlines added by 'escapeArgs'
+    escapeFilePath fp = trimEnd $ escapeArgs [fp]
 
 -- | @'cabalCradleDependencies' rootDir componentDir@.
 -- Compute the dependencies of the cabal cradle based
@@ -473,8 +577,7 @@ processCabalWrapperArgs args =
             let final_args =
                     removeVerbosityOpts
                     $ removeRTS
-                    $ removeInteractive
-                    $ ghc_args
+                    $ removeInteractive ghc_args
             in Just (dir, final_args)
         _ -> Nothing
 
@@ -483,69 +586,109 @@ processCabalWrapperArgs args =
 -- arguments to the executable.
 type GhcProc = (FilePath, [String])
 
--- | Generate a fake GHC that can be passed to cabal
+-- | Generate a fake GHC that can be passed to cabal or stack
 -- when run with --interactive, it will print out its
 -- command-line arguments and exit
-withCabalWrapperTool :: GhcProc -> FilePath -> IO FilePath
-withCabalWrapperTool (mbGhc, ghcArgs) wdir = do
-    cacheDir <- getCacheDir ""
-    createDirectoryIfMissing True cacheDir
+withGhcWrapperTool :: GhcProc -> FilePath -> IO FilePath
+withGhcWrapperTool (mbGhc, ghcArgs) wdir = do
     let wrapperContents = if isWindows then cabalWrapperHs else cabalWrapper
-        suffix fp = if isWindows then fp <.> "exe" else fp
-    let srcHash = show (fingerprintString wrapperContents)
-    let wrapper_name = "wrapper-" ++ srcHash
-    let wrapper_fp = suffix $ cacheDir </> wrapper_name
-    exists <- doesFileExist wrapper_fp
-    unless exists $
+        withExtension fp = if isWindows then fp <.> "exe" else fp
+        srcHash = show (fingerprintString wrapperContents)
+    cacheFile (withExtension "wrapper") srcHash $ \wrapper_fp ->
       if isWindows
-      then do
+      then
         withSystemTempDirectory "hie-bios" $ \ tmpDir -> do
-          let wrapper_hs = cacheDir </> wrapper_name <.> "hs"
+          let wrapper_hs = wrapper_fp -<.> "hs"
           writeFile wrapper_hs wrapperContents
           let ghc = (proc mbGhc $
                       ghcArgs ++ ["-rtsopts=ignore", "-outputdir", tmpDir, "-o", wrapper_fp, wrapper_hs])
                       { cwd = Just wdir }
           readCreateProcess ghc "" >>= putStr
       else writeFile wrapper_fp wrapperContents
-    setMode wrapper_fp
-    pure wrapper_fp
+
+-- | Create and cache a file in hie-bios's cache directory.
+--
+-- @'cacheFile' fpName srcHash populate@. 'fpName' is the pattern name of the
+-- cached file you want to create. 'srcHash' is the hash that is appended to
+-- the file pattern and is expected to change whenever you want to invalidate
+-- the cache.
+--
+-- If the cached file's 'srcHash' changes, then a new file is created, but
+-- the old cached file name will not be deleted.
+--
+-- If the file does not exist yet, 'populate' is invoked with cached file
+-- location and it is expected that the caller persists the given filepath in
+-- the File System.
+cacheFile :: FilePath -> String -> (FilePath -> IO ()) -> IO FilePath
+cacheFile fpName srcHash populate = do
+  cacheDir <- getCacheDir ""
+  createDirectoryIfMissing True cacheDir
+  let newFpName = cacheDir </> (dropExtensions fpName <> "-" <> srcHash) <.> takeExtensions fpName
+  unlessM (doesFileExist newFpName) $ do
+    populate newFpName
+    setMode newFpName
+  pure newFpName
   where
     setMode wrapper_fp = setFileMode wrapper_fp accessModes
 
 -- | Given the root directory, get the build dir we are using for cabal
 -- In the `hie-bios` cache directory
 cabalBuildDir :: FilePath -> IO FilePath
-cabalBuildDir work_dir = do
-  abs_work_dir <- makeAbsolute work_dir
+cabalBuildDir workDir = do
+  abs_work_dir <- makeAbsolute workDir
   let dirHash = show (fingerprintString abs_work_dir)
-  getCacheDir ("dist-"<>filter (not . isSpace) (takeBaseName abs_work_dir)<>"-"<>dirHash)
+  getCacheDir ("dist-" <> filter (not . isSpace) (takeBaseName abs_work_dir)<>"-"<>dirHash)
+
+-- | Discover the location of the ghc binary 'cabal' is going to use together
+-- with its libdir location.
+-- The ghc executable is an absolute path, but not necessarily canonicalised
+-- or normalised. Additionally, the ghc path returned is likely to be the raw
+-- executable, i.e. without the usual wrapper shims on non-windows systems.
+-- If you want to use the given ghc executable, you should invoke
+-- 'withGhcWrapperTool'.
+--
+-- If cabal can not figure it out, a 'CradleError' is returned.
+cabalGhcDirs :: FilePath -> IO (CradleLoadResult (FilePath, FilePath))
+cabalGhcDirs workDir = do
+  libdirLoadResult <- readProcessWithCwd workDir  "cabal" ["exec", "-v0", "--", "ghc", "--print-libdir"] ""
+  libdirLoadResult `bindIO` \libdir -> do
+    exePathLoadResult <- readProcessWithCwd workDir  "cabal"
+        ["exec", "-v0", "--", "ghc", "-package-env=-", "-e", "do e <- System.Environment.getExecutablePath ; System.IO.putStr e"] ""
+    exePathLoadResult `bindIO` \exe -> pure $ CradleSuccess (trimEnd exe, trimEnd libdir)
 
 cabalAction :: FilePath -> Maybe String -> LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
-cabalAction work_dir mc l fp = do
-    wrapper_fp <- withCabalWrapperTool ("ghc", []) work_dir
-    buildDir <- cabalBuildDir work_dir
-    let cab_args = ["--builddir="<>buildDir,"v2-repl", "--with-compiler", wrapper_fp, fromMaybe (fixTargetPath fp) mc]
-    (ex, output, stde, [(_,mb_args)]) <-
-      readProcessWithOutputs [hie_bios_output] l work_dir (proc "cabal" cab_args)
-    let args = fromMaybe [] mb_args
-    case processCabalWrapperArgs args of
+cabalAction workDir mc l fp =
+  cabalProcess workDir "v2-repl" [fromMaybe (fixTargetPath fp) mc] >>= \case
+    CradleNone -> pure CradleNone
+    CradleFail err -> do
+      -- Provide some dependencies an IDE can look for to trigger a reload.
+      -- Best effort. Assume the working directory is the
+      -- root of the component, so we are right in trivial cases at least.
+      deps <- cabalCradleDependencies workDir workDir
+      pure $ CradleFail err { cradleErrorDependencies = cradleErrorDependencies err ++ deps }
+    CradleSuccess cabalProc -> do
+      (ex, output, stde, [(_, maybeArgs)]) <- readProcessWithOutputs [hie_bios_output] l workDir cabalProc
+
+      let args = fromMaybe [] maybeArgs
+      case processCabalWrapperArgs args of
         Nothing -> do
+          -- Provide some dependencies an IDE can look for to trigger a reload.
           -- Best effort. Assume the working directory is the
-          -- the root of the component, so we are right in trivial cases at least.
-          deps <- cabalCradleDependencies work_dir work_dir
+          -- root of the component, so we are right in trivial cases at least.
+          deps <- cabalCradleDependencies workDir workDir
           pure $ CradleFail (CradleError deps ex
                     ["Failed to parse result of calling cabal"
-                     , unlines output
-                     , unlines stde
-                     , unlines $ args])
+                    , unlines output
+                    , unlines stde
+                    , unlines $ args])
         Just (componentDir, final_args) -> do
-          deps <- cabalCradleDependencies work_dir componentDir
+          deps <- cabalCradleDependencies workDir componentDir
           pure $ makeCradleResult (ex, stde, componentDir, final_args) deps
   where
     -- Need to make relative on Windows, due to a Cabal bug with how it
     -- parses file targets with a C: drive in it
     fixTargetPath x
-      | isWindows && hasDrive x = makeRelative work_dir x
+      | isWindows && hasDrive x = makeRelative workDir x
       | otherwise = x
 
 removeInteractive :: [String] -> [String]
@@ -650,26 +793,26 @@ stackCradleDependencies wdir componentDir syaml = do
     cabalFiles ++ [relFp </> "package.yaml", stackYamlLocationOrDefault syaml]
 
 stackAction :: FilePath -> Maybe String -> StackYaml -> LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
-stackAction work_dir mc syaml l _fp = do
+stackAction workDir mc syaml l _fp = do
   let ghcProcArgs = ("stack", stackYamlProcessArgs syaml <> ["exec", "ghc", "--"])
   -- Same wrapper works as with cabal
-  wrapper_fp <- withCabalWrapperTool ghcProcArgs work_dir
-  (ex1, _stdo, stde, [(_, mb_args)]) <-
-    readProcessWithOutputs [hie_bios_output] l work_dir $
+  wrapper_fp <- withGhcWrapperTool ghcProcArgs workDir
+  (ex1, _stdo, stde, [(_, maybeArgs)]) <-
+    readProcessWithOutputs [hie_bios_output] l workDir $
     stackProcess syaml
                 $  ["repl", "--no-nix-pure", "--with-ghc", wrapper_fp]
                     <> [ comp | Just comp <- [mc] ]
   (ex2, pkg_args, stdr, _) <-
-    readProcessWithOutputs [hie_bios_output] l work_dir $
+    readProcessWithOutputs [hie_bios_output] l workDir $
       stackProcess syaml ["path", "--ghc-package-path"]
   let split_pkgs = concatMap splitSearchPath pkg_args
       pkg_ghc_args = concatMap (\p -> ["-package-db", p] ) split_pkgs
-      args = fromMaybe [] mb_args
+      args = fromMaybe [] maybeArgs
   case processCabalWrapperArgs args of
       Nothing -> do
         -- Best effort. Assume the working directory is the
         -- the root of the component, so we are right in trivial cases at least.
-        deps <- stackCradleDependencies work_dir work_dir syaml
+        deps <- stackCradleDependencies workDir workDir syaml
         pure $ CradleFail
                   (CradleError deps ex1 $
                     [ "Failed to parse result of calling stack" ]
@@ -678,7 +821,7 @@ stackAction work_dir mc syaml l _fp = do
                   )
 
       Just (componentDir, ghc_args) -> do
-        deps <- stackCradleDependencies work_dir componentDir syaml
+        deps <- stackCradleDependencies workDir componentDir syaml
         pure $ makeCradleResult
                   ( combineExitCodes [ex1, ex2]
                   , stde ++ stdr, componentDir
@@ -730,15 +873,15 @@ bazelCommand :: String
 bazelCommand = $(embedStringFile "wrappers/bazel")
 
 rulesHaskellAction :: FilePath -> FilePath -> IO (CradleLoadResult ComponentOptions)
-rulesHaskellAction work_dir fp = do
+rulesHaskellAction workDir fp = do
   wrapper_fp <- writeSystemTempFile "wrapper" bazelCommand
   setFileMode wrapper_fp accessModes
-  let rel_path = makeRelative work_dir fp
+  let rel_path = makeRelative workDir fp
   (ex, args, stde) <-
-      readProcessWithOutputFile work_dir wrapper_fp [rel_path] []
+      readProcessWithOutputFile workDir wrapper_fp [rel_path] []
   let args'  = filter (/= '\'') args
   let args'' = filter (/= "\"$GHCI_LOCATION\"") (words args')
-  deps <- rulesHaskellCradleDependencies work_dir
+  deps <- rulesHaskellCradleDependencies workDir
   return $ makeCradleResult (ex, stde, args'') deps
 
 
@@ -769,11 +912,11 @@ obeliskCradle wdir =
     }
 
 obeliskAction :: FilePath -> FilePath -> IO (CradleLoadResult ComponentOptions)
-obeliskAction work_dir _fp = do
+obeliskAction workDir _fp = do
   (ex, args, stde) <-
-      readProcessWithOutputFile work_dir "ob" ["ide-args"] []
+      readProcessWithOutputFile workDir "ob" ["ide-args"] []
 
-  o_deps <- obeliskCradleDependencies work_dir
+  o_deps <- obeliskCradleDependencies workDir
   return (makeCradleResult (ex, stde, words args) o_deps )
 
 -}
@@ -808,13 +951,12 @@ findFile p dir = do
     getFiles = filter p <$> getDirectoryContents dir
     doesPredFileExist file = doesFileExist $ dir </> file
 
--- Some environments (e.g. stack exec) include GHC_PACKAGE_PATH.
--- Cabal v2 *will* complain, even though or precisely because it ignores them
+-- | Some environments (e.g. stack exec) include GHC_PACKAGE_PATH.
+-- Cabal v2 *will* complain, even though or precisely because it ignores them.
 -- Unset them from the environment to sidestep this
 getCleanEnvironment :: IO [(String, String)]
 getCleanEnvironment = do
-  e <- getEnvironment
-  return $ Map.toList $ Map.delete "GHC_PACKAGE_PATH" $ Map.fromList e
+  Map.toList . Map.delete "GHC_PACKAGE_PATH" . Map.fromList <$> getEnvironment
 
 type Outputs = [OutputName]
 type OutputName = String
@@ -831,16 +973,17 @@ readProcessWithOutputs
   -> FilePath -- ^ Working directory. Process is executed in this directory.
   -> CreateProcess -- ^ Parameters for the process to be executed.
   -> IO (ExitCode, [String], [String], [(OutputName, Maybe [String])])
-readProcessWithOutputs outputNames l work_dir cp = flip runContT return $ do
+readProcessWithOutputs outputNames l workDir cp = flip runContT return $ do
   old_env <- liftIO getCleanEnvironment
   output_files <- traverse (withOutput old_env) outputNames
 
   let process = cp { env = Just $ output_files ++ fromMaybe old_env (env cp),
-                     cwd = Just work_dir
+                     cwd = Just workDir
                     }
 
     -- Windows line endings are not converted so you have to filter out `'r` characters
-  let  loggingConduit = C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')  C..| C.map T.unpack C..| C.iterM l C..| C.sinkList
+  let loggingConduit = C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')
+        C..| C.map T.unpack C..| C.iterM l C..| C.sinkList
   (ex, stdo, stde) <- liftIO $ sourceProcessWithStreams process mempty loggingConduit loggingConduit
 
   res <- forM output_files $ \(name,path) ->
@@ -890,15 +1033,28 @@ runGhcCmdOnPath wdir args = readProcessWithCwd wdir "ghc" args ""
   -- case mResult of
   --   Nothing
 
--- | Wrapper around 'readCreateProcess' that sets the working directory
+-- | Wrapper around 'readCreateProcess' that sets the working directory and
+-- clears the environment, suitable for invoking cabal/stack and raw ghc commands.
 readProcessWithCwd :: FilePath -> FilePath -> [String] -> String -> IO (CradleLoadResult String)
-readProcessWithCwd dir cmd args stdi = do
+readProcessWithCwd dir cmd args stdin = do
   cleanEnv <- getCleanEnvironment
   let createProc = (proc cmd args) { cwd = Just dir, env = Just cleanEnv }
-  mResult <- optional $ readCreateProcessWithExitCode createProc stdi
+  readProcessWithCwd' createProc stdin
+
+-- | Wrapper around 'readCreateProcessWithExitCode', wrapping the result in
+-- a 'CradleLoadResult'. Provides better error messages than raw 'readCreateProcess'.
+readProcessWithCwd' :: CreateProcess -> String -> IO (CradleLoadResult String)
+readProcessWithCwd' createdProcess stdin = do
+  mResult <- optional $ readCreateProcessWithExitCode createdProcess stdin
+  let cmdString = prettyCmdSpec $ cmdspec createdProcess
   case mResult of
     Just (ExitSuccess, stdo, _) -> pure $ CradleSuccess stdo
     Just (exitCode, stdo, stde) -> pure $ CradleFail $
-      CradleError [] exitCode ["Error when calling " <> cmd <> " " <> unwords args, stdo, stde]
+      CradleError [] exitCode ["Error when calling " <> cmdString, stdo, stde]
     Nothing -> pure $ CradleFail $
-      CradleError [] ExitSuccess ["Couldn't execute " <> cmd <> " " <> unwords args]
+      CradleError [] ExitSuccess ["Couldn't execute " <> cmdString]
+
+-- | Prettify 'CmdSpec', so we can show the command to a user
+prettyCmdSpec :: CmdSpec -> String
+prettyCmdSpec (ShellCommand s) = s
+prettyCmdSpec (RawCommand cmd args) = cmd ++ " " ++ unwords args

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveFoldable #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {-# LANGUAGE DeriveFoldable #-}
@@ -68,7 +70,6 @@ data CradleLoadResult r
   | CradleNone -- ^ No attempt was made to load the cradle.
  deriving (Functor, Foldable, Traversable, Show, Eq)
 
-
 instance Applicative CradleLoadResult where
   pure = CradleSuccess
   CradleSuccess a <*> CradleSuccess b = CradleSuccess (a b)
@@ -86,7 +87,6 @@ bindIO :: CradleLoadResult a -> (a -> IO (CradleLoadResult b)) -> IO (CradleLoad
 bindIO  (CradleSuccess r) k = k r
 bindIO (CradleFail err) _ = return $ CradleFail err
 bindIO CradleNone _ = return CradleNone
-
 
 data CradleError = CradleError
   { cradleErrorDependencies :: [FilePath]

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -11,6 +12,12 @@ module HIE.Bios.Types where
 
 import           System.Exit
 import           Control.Exception              ( Exception )
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+#if MIN_VERSION_base(4,9,0)
+import qualified Control.Monad.Fail as Fail
+#endif
 
 data BIOSVerbosity = Silent | Verbose
 
@@ -70,6 +77,11 @@ data CradleLoadResult r
   | CradleNone -- ^ No attempt was made to load the cradle.
  deriving (Functor, Foldable, Traversable, Show, Eq)
 
+cradleLoadResult :: c -> (CradleError -> c) -> (r -> c) -> CradleLoadResult r -> c
+cradleLoadResult c _ _ CradleNone        = c
+cradleLoadResult _ f _ (CradleFail e)    = f e
+cradleLoadResult _ _ f (CradleSuccess r) = f r
+
 instance Applicative CradleLoadResult where
   pure = CradleSuccess
   CradleSuccess a <*> CradleSuccess b = CradleSuccess (a b)
@@ -83,10 +95,65 @@ instance Monad CradleLoadResult where
   CradleFail err >>= _ = CradleFail err
   CradleNone >>= _ = CradleNone
 
-bindIO :: CradleLoadResult a -> (a -> IO (CradleLoadResult b)) -> IO (CradleLoadResult b)
-bindIO  (CradleSuccess r) k = k r
-bindIO (CradleFail err) _ = return $ CradleFail err
-bindIO CradleNone _ = return CradleNone
+newtype CradleLoadResultT m a = CradleLoadResultT { runCradleResultT :: m (CradleLoadResult a) }
+
+instance Functor f => Functor (CradleLoadResultT f) where
+  {-# INLINE fmap #-}
+  fmap f = CradleLoadResultT . (fmap . fmap) f . runCradleResultT
+
+instance (Monad m, Applicative m) => Applicative (CradleLoadResultT m) where
+  {-# INLINE pure #-}
+  pure = CradleLoadResultT . pure . CradleSuccess
+  {-# INLINE (<*>) #-}
+  x <*> f = CradleLoadResultT $ do
+              a <- runCradleResultT x
+              case a of
+                CradleSuccess a' -> do
+                  b <- runCradleResultT f
+                  case b of
+                    CradleSuccess b' -> pure (CradleSuccess (a' b'))
+                    CradleFail err -> pure $ CradleFail err
+                    CradleNone -> pure CradleNone
+                CradleFail err -> pure $ CradleFail err
+                CradleNone -> pure CradleNone
+
+instance Monad m => Monad (CradleLoadResultT m) where
+  {-# INLINE return #-}
+  return = CradleLoadResultT . return . CradleSuccess
+  {-# INLINE (>>=) #-}
+  x >>= f = CradleLoadResultT $ do
+    val <- runCradleResultT x
+    case val of
+      CradleSuccess r -> runCradleResultT . f $ r
+      CradleFail err -> return $ CradleFail err
+      CradleNone -> return $ CradleNone
+#if !(MIN_VERSION_base(4,13,0))
+  fail = CradleLoadResultT . fail
+  {-# INLINE fail #-}
+#endif
+#if MIN_VERSION_base(4,9,0)
+instance Fail.MonadFail m => Fail.MonadFail (CradleLoadResultT m) where
+  fail = CradleLoadResultT . Fail.fail
+  {-# INLINE fail #-}
+#endif
+
+instance MonadTrans CradleLoadResultT where
+    lift = CradleLoadResultT . liftM CradleSuccess
+    {-# INLINE lift #-}
+
+instance (MonadIO m) => MonadIO (CradleLoadResultT m) where
+    liftIO = lift . liftIO
+    {-# INLINE liftIO #-}
+
+modCradleError :: Monad m => CradleLoadResultT m a -> (CradleError -> m CradleError) -> CradleLoadResultT m a
+modCradleError action f = CradleLoadResultT $ do
+  a <- runCradleResultT action
+  case a of
+    CradleFail err -> CradleFail <$> f err
+    _ -> pure a
+
+throwCE :: Monad m => CradleError -> CradleLoadResultT m a
+throwCE = CradleLoadResultT . return . CradleFail
 
 data CradleError = CradleError
   { cradleErrorDependencies :: [FilePath]

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -157,8 +157,7 @@ cabalTestCases extraGhcDep =
             testImplicitCradle "./tests/projects/implicit-cabal-deep-project" "foo/Main.hs" Cabal
         ]
   , testGroupWithDependency extraGhcDep
-    [ expectFailBecause "hie-bios does not honour ghc in cabal.project"
-      $ testCaseSteps "Appropriate ghc and libdir" $ \step -> do
+    [ testCaseSteps "Appropriate ghc and libdir" $ \step -> do
         fp <- canonicalizePath "./tests/projects/cabal-with-ghc/src/MyLib.hs"
         crd <- initialiseCradle isCabalCradle fp step
         step "Get runtime GHC library directory"

--- a/wrappers/cabal
+++ b/wrappers/cabal
@@ -10,5 +10,5 @@ if [ "$1" == "--interactive" ]; then
     out "$arg"
   done
 else
-  "ghc" "$@"
+  "${HIE_BIOS_GHC:-ghc}" "${HIE_BIOS_GHC_ARGS}" "$@"
 fi

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -1,7 +1,8 @@
 module Main (main) where
 
+import Data.Maybe (fromMaybe)
 import System.Directory (getCurrentDirectory)
-import System.Environment (getArgs, getEnv)
+import System.Environment (getArgs, getEnv, lookupEnv)
 import System.Exit (exitWith)
 import System.Process (spawnProcess, waitForProcess)
 import System.IO (openFile, hClose, hPutStrLn, IOMode(..))
@@ -17,6 +18,7 @@ main = do
       mapM_ (hPutStrLn h) args
       hClose h
     _ -> do
-      ph <- spawnProcess "ghc" (args)
+      ghc_path <- fromMaybe "ghc" <$> lookupEnv "HIE_BIOS_GHC"
+      ph <- spawnProcess ghc_path (args)
       code <- waitForProcess ph
       exitWith code


### PR DESCRIPTION
WIP with @fendor to use the proper GHC version provided by Cabal instead of using blindingly the one in $PATH.