### PR TITLE
hie-bios --help now works even with a faulty hie.yaml

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -59,13 +59,13 @@ main :: IO ()
 main = do
     hSetEncoding stdout utf8
     cwd <- getCurrentDirectory
+    cmd <- execParser progInfo
     cradle <-
         -- find cradle does a takeDirectory on the argument, so make it into a file
         findCradle (cwd </> "File.hs") >>= \case
           Just yaml -> loadCradle yaml
           Nothing -> loadImplicitCradle (cwd </> "File.hs")
 
-    cmd <- execParser progInfo
 
     res <- case cmd of
       Check targetFiles -> checkSyntax cradle targetFiles


### PR DESCRIPTION
Running `hie-bios --help` in a folder with a faulty hie.yaml would crash
straightaway with for instance:
```
hie-bios: AesonException "Error in $.cradle.cradle: Not a known cradle type. Possible are: cabal, stack, bios, direct, default, none, multi"
```
without displaying the help. This should not happen.

NB: Would you mind if I opened a PR to add a flake.nix ? like haskell-language-server does. 