### PR TITLE
Fix compilation with GHC 9.0.2

### DIFF
--- a/src/HIE/Bios/Ghc/Gap.hs
+++ b/src/HIE/Bios/Ghc/Gap.hs
@@ -260,7 +260,7 @@ mapOverIncludePaths f df = df
       G.IncludeSpecs
           (map f $ G.includePathsQuote  (includePaths df))
           (map f $ G.includePathsGlobal (includePaths df))
-#if __GLASGOW_HASKELL__ >= 902
+#if MIN_VERSION_GLASGOW_HASKELL(9,0,2,0)
           (map f $ G.includePathsQuoteImplicit (includePaths df))
 #endif
 #else


### PR DESCRIPTION
GHC commit [7f1fff5][1] which is included in 9.0.2 is a backport of an
API change to the IncludeSpecs record of 9.2.1 which is already
accounted for by an `__GLASGOW_HASKELL__` CPP guard. For 9.0.2
compatibility, we simply need to hit this guard for 9.0.2 as well, but
not for 9.0.1.

[1]: https://gitlab.haskell.org/ghc/ghc/-/commit/7f1fff501faa9525ca09bde076059a65388d638a