### PR TITLE
Add CI support for GHC 9.0.2 and GHC 9.2.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.0.1', '8.10.4', '8.8.4', '8.6.5', '8.4.4']
+        ghc: ['9.0.2', '9.0.1', '8.10.4', '8.8.4', '8.6.5', '8.4.4']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
           - os: macOS-latest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,6 +13,8 @@ jobs:
         exclude:
           - os: macOS-latest
             ghc: '8.4.4' # fails due to ghc panic
+          - os: windows-latest
+            ghc: '9.0.2' # fails due to unix-compat being incompatible
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2'
+        cabal-version: '3.6'
         enable-stack: true
 
     - name: Cache Cabal

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,13 +8,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.0.2', '9.0.1', '8.10.4', '8.8.4', '8.6.5', '8.4.4']
+        ghc: ['9.2.1', '9.0.2', '9.0.1', '8.10.4', '8.8.4', '8.6.5', '8.4.4']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
           - os: macOS-latest
             ghc: '8.4.4' # fails due to ghc panic
           - os: windows-latest
             ghc: '9.0.2' # fails due to unix-compat being incompatible
+          - os: windows-latest
+            ghc: '9.2.1' # fails due to unix-compat being incompatible
 
     steps:
     - uses: actions/checkout@v2

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -121,7 +121,7 @@ Extra-Source-Files:     ChangeLog.md
                         tests/projects/stack-with-yaml/stack-with-yaml.cabal
                         tests/projects/stack-with-yaml/src/Lib.hs
 
-tested-with: GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4
+tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 
 Library
   Default-Language:     Haskell2010

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -121,7 +121,7 @@ Extra-Source-Files:     ChangeLog.md
                         tests/projects/stack-with-yaml/stack-with-yaml.cabal
                         tests/projects/stack-with-yaml/src/Lib.hs
 
-tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
+tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1 || ==9.0.2
 
 Library
   Default-Language:     Haskell2010

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -121,7 +121,7 @@ Extra-Source-Files:     ChangeLog.md
                         tests/projects/stack-with-yaml/stack-with-yaml.cabal
                         tests/projects/stack-with-yaml/src/Lib.hs
 
-tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1 || ==9.0.2
+tested-with: GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1 || ==9.0.2 || ==9.2.1
 
 Library
   Default-Language:     Haskell2010

--- a/tests/projects/deps-bios-new/hie-bios.sh
+++ b/tests/projects/deps-bios-new/hie-bios.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo "-Wall" >> $HIE_BIOS_OUTPUT
 echo "A" >> $HIE_BIOS_OUTPUT
 echo "B" >> $HIE_BIOS_OUTPUT

--- a/tests/projects/simple-bios-ghc/hie-bios.sh
+++ b/tests/projects/simple-bios-ghc/hie-bios.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo "-Wall" >> $HIE_BIOS_OUTPUT
 echo "A" >> $HIE_BIOS_OUTPUT
 echo "B" >> $HIE_BIOS_OUTPUT

--- a/tests/projects/simple-bios/hie-bios-deps.sh
+++ b/tests/projects/simple-bios/hie-bios-deps.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 echo "hie-bios.sh" >> $HIE_BIOS_OUTPUT

--- a/tests/projects/simple-bios/hie-bios.sh
+++ b/tests/projects/simple-bios/hie-bios.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo "-Wall" >> $HIE_BIOS_OUTPUT
 echo "A" >> $HIE_BIOS_OUTPUT
 echo "B" >> $HIE_BIOS_OUTPUT


### PR DESCRIPTION
Skips Windows CI as one of the dependencies (unix-compat) doesn't build for GHC 9.0.2 and 9.2.1

Once green, will be released.