### PR TITLE
Allow text-2.0

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -165,7 +165,7 @@ Library
                         ghc                  >= 8.6.1 && < 9.3,
                         transformers         >= 0.5.2 && < 0.7,
                         temporary            >= 1.2 && < 1.4,
-                        text                 >= 1.2.3 && < 2,
+                        text                 >= 1.2.3 && < 2.1,
                         unix-compat          >= 0.5.1 && < 0.6,
                         unordered-containers >= 0.2.9 && < 0.3,
                         vector               >= 0.12.0 && < 0.13,


### PR DESCRIPTION
Tested with `cabal test -w ghc-9.0 --constraint 'text >= 2.0'`.