### PR TITLE
fix typos

### DIFF
--- a/src/HIE/Bios/Ghc/Load.hs
+++ b/src/HIE/Bios/Ghc/Load.hs
@@ -120,7 +120,7 @@ collectASTs action = do
   Gap.modifySession $ Gap.setFrontEndHooks (Just (astHook ref1))
   res <- action
   tcs <- liftIO $ readIORef ref1
-  -- Unset the hook so that we don't retain the reference ot the IORef so it can be gced.
+  -- Unset the hook so that we don't retain the reference to the IORef so it can be GCed.
   -- This stops the typechecked modules being retained in some cases.
   liftIO $ writeIORef ref1 []
   Gap.modifySession $ Gap.setFrontEndHooks Nothing


### PR DESCRIPTION
src/HIE/Bios/Ghc/Load.hs

<hr>

src/HIE/Bios/Ghc/{Api.hs,Load.hs}

FWIW, Messager/messager is an obsolete form of Messenger/messenger.