### PR TITLE
Demote process output to Debug severity

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -1027,7 +1027,7 @@ readProcessWithOutputs outputNames l workDir cp = flip runContT return $ do
 
     -- Windows line endings are not converted so you have to filter out `'r` characters
   let loggingConduit = C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')
-        C..| C.map T.unpack C..| C.iterM (\msg -> l <& LogAny msg `WithSeverity` Debug) C..| C.sinkList
+        C..| C.map T.unpack C..| C.iterM (\msg -> l <& LogProcessOutput msg `WithSeverity` Debug) C..| C.sinkList
   (ex, stdo, stde) <- liftIO $ sourceProcessWithStreams process mempty loggingConduit loggingConduit
 
   res <- forM output_files $ \(name,path) ->

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -1027,7 +1027,7 @@ readProcessWithOutputs outputNames l workDir cp = flip runContT return $ do
 
     -- Windows line endings are not converted so you have to filter out `'r` characters
   let loggingConduit = C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')
-        C..| C.map T.unpack C..| C.iterM (\msg -> l <& LogAny msg `WithSeverity` Info) C..| C.sinkList
+        C..| C.map T.unpack C..| C.iterM (\msg -> l <& LogAny msg `WithSeverity` Debug) C..| C.sinkList
   (ex, stdo, stde) <- liftIO $ sourceProcessWithStreams process mempty loggingConduit loggingConduit
 
   res <- forM output_files $ \(name,path) ->

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -54,7 +54,9 @@ data ActionName a
   | Other a
   deriving (Show, Eq, Ord, Functor)
 
-data Log = LogAny String
+data Log = 
+  LogAny String
+  | LogProcessOutput String
   deriving Show
 
 instance Pretty Log where


### PR DESCRIPTION
This is perhaps a more controversial change. The process output is quite
noisy, and arguably not of interest unless you're debugging an issue.

The counterargument is that if something *does* go wrong with running the
cradle command, it's useful to see it. Perhaps we could collect the
output and only emit it on failure?