### PR TITLE
Cabal cradle: change error message on failure

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -721,7 +721,7 @@ cabalAction workDir mc l fp = do
   when (ex /= ExitSuccess) $ do
     deps <- liftIO $ cabalCradleDependencies workDir workDir
     let cmd = show (["cabal", cabalCommand] <> cabalArgs)
-    let errorMsg = "Failed to run " <> cmd <> " in directory \"" <> workDir <> "\". See below for full command and error."
+    let errorMsg = "Failed to run " <> cmd <> " in directory \"" <> workDir <> "\". Consult the logs for full command and error."
     throwCE (CradleError deps ex ([errorMsg] <> errorDetails))
 
   case processCabalWrapperArgs args of


### PR DESCRIPTION
This changes the first line of the error message that is shown when the cabal cradle fails to

```
Failed to run ["cabal", "v2-repl",  ..] in directory  "/home/foo/...". See below for full command and error.
```

(the error message was `Failed to parse result of calling cabal` before, which is less informative).

cc @fendor 