### PR TITLE
Add support for non-standard cabal.project file locations to cabal cradles

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -21,6 +21,14 @@ Extra-Source-Files:     ChangeLog.md
                         tests/projects/cabal-with-ghc/cabal.project
                         tests/projects/cabal-with-ghc/hie.yaml
                         tests/projects/cabal-with-ghc/src/MyLib.hs
+                        tests/projects/cabal-with-ghc-and-project/cabal-with-ghc.cabal
+                        tests/projects/cabal-with-ghc-and-project/cabal.project.8.10.7
+                        tests/projects/cabal-with-ghc-and-project/hie.yaml
+                        tests/projects/cabal-with-ghc-and-project/src/MyLib.hs
+                        tests/projects/cabal-with-project/cabal-with-project.cabal
+                        tests/projects/cabal-with-project/cabal.project.8.10.7
+                        tests/projects/cabal-with-project/hie.yaml
+                        tests/projects/cabal-with-project/src/MyLib.hs
                         tests/projects/symlink-test/a/A.hs
                         tests/projects/symlink-test/hie.yaml
                         tests/projects/deps-bios-new/A.hs
@@ -35,6 +43,12 @@ Extra-Source-Files:     ChangeLog.md
                         tests/projects/multi-cabal/hie.yaml
                         tests/projects/multi-cabal/multi-cabal.cabal
                         tests/projects/multi-cabal/src/Lib.hs
+                        tests/projects/multi-cabal-with-project/appA/appA.cabal
+                        tests/projects/multi-cabal-with-project/appA/src/Lib.hs
+                        tests/projects/multi-cabal-with-project/appB/appB.cabal
+                        tests/projects/multi-cabal-with-project/appB/src/Lib.hs
+                        tests/projects/multi-cabal-with-project/cabal.project.8.10.7
+                        tests/projects/multi-cabal-with-project/hie.yaml
                         tests/projects/monorepo-cabal/cabal.project
                         tests/projects/monorepo-cabal/hie.yaml
                         tests/projects/monorepo-cabal/A/Main.hs

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -26,7 +26,7 @@ configDir = "tests/configs"
 main :: IO ()
 main = defaultMain $
   testCase "Parser Tests" $ do
-    assertParser "cabal-1.yaml" (noDeps (Cabal $ CabalType (Just "lib:hie-bios")))
+    assertParser "cabal-1.yaml" (noDeps (Cabal $ CabalType (Just "lib:hie-bios") Nothing))
     assertParser "stack-config.yaml" (noDeps (Stack $ StackType Nothing Nothing))
     --assertParser "bazel.yaml" (noDeps Bazel)
     assertParser "bios-1.yaml" (noDeps (Bios (Program "program") Nothing Nothing))
@@ -34,16 +34,16 @@ main = defaultMain $
     assertParser "bios-3.yaml" (noDeps (Bios (Command "shellcommand") Nothing Nothing))
     assertParser "bios-4.yaml" (noDeps (Bios (Command "shellcommand") (Just (Command "dep-shellcommand")) Nothing))
     assertParser "bios-5.yaml" (noDeps (Bios (Command "shellcommand") (Just (Program "dep-program")) Nothing))
-    assertParser "dependencies.yaml" (Config (CradleConfig ["depFile"] (Cabal $ CabalType (Just "lib:hie-bios"))))
+    assertParser "dependencies.yaml" (Config (CradleConfig ["depFile"] (Cabal $ CabalType (Just "lib:hie-bios") Nothing)))
     assertParser "direct.yaml" (noDeps (Direct ["list", "of", "arguments"]))
     assertParser "none.yaml" (noDeps None)
     --assertParser "obelisk.yaml" (noDeps Obelisk)
-    assertParser "multi.yaml" (noDeps (Multi [("./src", CradleConfig [] (Cabal $ CabalType (Just "lib:hie-bios")))
-                                             ,("./test", CradleConfig [] (Cabal $ CabalType (Just "test")) ) ]))
+    assertParser "multi.yaml" (noDeps (Multi [("./src", CradleConfig [] (Cabal $ CabalType (Just "lib:hie-bios") Nothing))
+                                             ,("./test", CradleConfig [] (Cabal $ CabalType (Just "test") Nothing))]))
 
-    assertParser "cabal-multi.yaml" (noDeps (CabalMulti (CabalType Nothing)
-                                                        [("./src", CabalType $ Just "lib:hie-bios")
-                                                        ,("./", CabalType $ Just "lib:hie-bios")]))
+    assertParser "cabal-multi.yaml" (noDeps (CabalMulti (CabalType Nothing Nothing)
+                                                        [("./src", CabalType (Just "lib:hie-bios") Nothing)
+                                                        ,("./", CabalType (Just "lib:hie-bios") Nothing)]))
 
     assertParser "stack-multi.yaml" (noDeps (StackMulti (StackType Nothing Nothing)
                                                         [("./src", StackType (Just "lib:hie-bios") Nothing)
@@ -51,15 +51,25 @@ main = defaultMain $
 
     assertParser "nested-cabal-multi.yaml" (noDeps (Multi [("./test/testdata", CradleConfig [] None)
                                                           ,("./", CradleConfig [] (
-                                                                    CabalMulti (CabalType Nothing)
-                                                                               [("./src", CabalType $ Just "lib:hie-bios")
-                                                                               ,("./tests", CabalType $ Just "parser-tests")]))]))
+                                                                    CabalMulti (CabalType Nothing Nothing)
+                                                                               [("./src", CabalType (Just "lib:hie-bios") Nothing)
+                                                                               ,("./tests", CabalType (Just "parser-tests") Nothing)]))]))
 
     assertParser "nested-stack-multi.yaml" (noDeps (Multi [("./test/testdata", CradleConfig [] None)
                                                           ,("./", CradleConfig [] (
                                                                     StackMulti (StackType Nothing Nothing)
                                                                                [("./src", StackType (Just "lib:hie-bios") Nothing)
                                                                                ,("./tests", StackType (Just "parser-tests") Nothing)]))]))
+    -- Assertions for cabal.project files
+    assertParser "cabal-with-project.yaml"
+      (noDeps (Cabal $ CabalType Nothing (Just "cabal.project.8.10.7")))
+    assertParser "cabal-with-both.yaml"
+      (noDeps (Cabal $ CabalType (Just "hie-bios:hie") (Just "cabal.project.8.10.7")))
+    assertParser "multi-cabal-with-project.yaml"
+      (noDeps (CabalMulti (CabalType Nothing (Just "cabal.project.8.10.7"))
+                          [("./src", CabalType (Just "lib:hie-bios") Nothing)
+                          ,("./vendor", CabalType (Just "parser-tests") Nothing)]))
+    -- Assertions for stack.yaml files
     assertParser "stack-with-yaml.yaml"
       (noDeps (Stack $ StackType Nothing (Just "stack-8.8.3.yaml")))
     assertParser "stack-with-both.yaml"
@@ -77,11 +87,11 @@ main = defaultMain $
       (noDeps (Multi
         [ ("./src", CradleConfig [] (Other CabalHelperStack $ simpleCabalHelperYaml "stack"))
         , ("./input", CradleConfig [] (Other CabalHelperCabal $ simpleCabalHelperYaml "cabal"))
-        , ("./test", CradleConfig [] (Cabal $ CabalType (Just "test")))
+        , ("./test", CradleConfig [] (Cabal $ CabalType (Just "test") Nothing))
         , (".", CradleConfig [] None)
         ]))
     assertParserFails "keys-not-unique-fails.yaml" invalidYamlException
-    assertParser "cabal-empty-config.yaml" (noDeps (Cabal $ CabalType Nothing))
+    assertParser "cabal-empty-config.yaml" (noDeps (Cabal $ CabalType Nothing Nothing))
 
 assertParser :: FilePath -> Config Void -> Assertion
 assertParser fp cc = do

--- a/tests/configs/cabal-with-both.yaml
+++ b/tests/configs/cabal-with-both.yaml
@@ -1,0 +1,4 @@
+cradle:
+  cabal:
+    project-file: "cabal.project.8.10.7"
+    component: "hie-bios:hie"

--- a/tests/configs/cabal-with-project.yaml
+++ b/tests/configs/cabal-with-project.yaml
@@ -1,0 +1,3 @@
+cradle:
+  cabal:
+    project-file: "cabal.project.8.10.7"

--- a/tests/configs/multi-cabal-with-project.yaml
+++ b/tests/configs/multi-cabal-with-project.yaml
@@ -1,0 +1,8 @@
+cradle:
+  cabal:
+    project-file: "cabal.project.8.10.7"
+    components:
+      - path: "./src"
+        component: "lib:hie-bios"
+      - path: "./vendor"
+        component: "parser-tests"

--- a/tests/projects/cabal-with-ghc-and-project/cabal-with-ghc.cabal
+++ b/tests/projects/cabal-with-ghc-and-project/cabal-with-ghc.cabal
@@ -1,0 +1,9 @@
+cabal-version:      2.4
+name:               cabal-with-ghc
+version:            0.1.0.0
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/tests/projects/cabal-with-ghc-and-project/cabal.project.8.10.7
+++ b/tests/projects/cabal-with-ghc-and-project/cabal.project.8.10.7
@@ -1,0 +1,12 @@
+packages: .
+
+-- It is intended that this ghc version is different to at least one ghc version
+-- that is tested in CI.
+--
+-- Project validates that hie-bios honours this field.
+--
+-- If you change this, make sure to also change the 'extraGhc' constant in
+-- 'tests/BiosTests.hs'.
+--
+-- Additionally, CI needs a proper setup to execute this test-case.
+with-compiler: ghc-8.10.7

--- a/tests/projects/cabal-with-ghc-and-project/hie.yaml
+++ b/tests/projects/cabal-with-ghc-and-project/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  cabal:
+    project-file: cabal.project.8.10.7

--- a/tests/projects/cabal-with-ghc-and-project/src/MyLib.hs
+++ b/tests/projects/cabal-with-ghc-and-project/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/tests/projects/cabal-with-project/cabal-with-project.cabal
+++ b/tests/projects/cabal-with-project/cabal-with-project.cabal
@@ -1,0 +1,9 @@
+cabal-version:      2.4
+name:               cabal-with-project
+version:            0.1.0.0
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/tests/projects/cabal-with-project/cabal.project.8.10.7
+++ b/tests/projects/cabal-with-project/cabal.project.8.10.7
@@ -1,0 +1,5 @@
+-- Test file.
+packages: ./
+
+package cabal-with-project
+    ghc-options: -O2

--- a/tests/projects/cabal-with-project/hie.yaml
+++ b/tests/projects/cabal-with-project/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  cabal:
+    project-file: cabal.project.8.10.7

--- a/tests/projects/cabal-with-project/src/MyLib.hs
+++ b/tests/projects/cabal-with-project/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/tests/projects/multi-cabal-with-project/appA/appA.cabal
+++ b/tests/projects/multi-cabal-with-project/appA/appA.cabal
@@ -1,0 +1,10 @@
+cabal-version:       2.0
+name:                appA
+version:             0.1.0.0
+build-type:          Simple
+
+library
+  exposed-modules: Lib
+  build-depends:       base >=4.10 && < 5, filepath
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/tests/projects/multi-cabal-with-project/appA/src/Lib.hs
+++ b/tests/projects/multi-cabal-with-project/appA/src/Lib.hs
@@ -1,0 +1,1 @@
+module Lib where

--- a/tests/projects/multi-cabal-with-project/appB/appB.cabal
+++ b/tests/projects/multi-cabal-with-project/appB/appB.cabal
@@ -1,0 +1,12 @@
+cabal-version:       2.0
+name:                appB
+version:             0.1.0.0
+build-type:          Simple
+
+library
+  exposed-modules: Lib
+  -- other-modules:
+  -- other-extensions:
+  build-depends:       base >=4.10 && < 5, filepath
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/tests/projects/multi-cabal-with-project/appB/src/Lib.hs
+++ b/tests/projects/multi-cabal-with-project/appB/src/Lib.hs
@@ -1,0 +1,1 @@
+module Lib where

--- a/tests/projects/multi-cabal-with-project/cabal.project.8.10.7
+++ b/tests/projects/multi-cabal-with-project/cabal.project.8.10.7
@@ -1,0 +1,6 @@
+packages: ./appA ./appB
+
+-- Only appA gets the config
+package appA
+    ghc-options: -O2
+

--- a/tests/projects/multi-cabal-with-project/hie.yaml
+++ b/tests/projects/multi-cabal-with-project/hie.yaml
@@ -1,0 +1,16 @@
+cradle:
+  multi:
+    - path: "appA"
+      config:
+        cradle:
+          cabal:
+            - path: appA/src
+              component: appA:lib
+              project-file: cabal.project.8.10.7
+    - path: "appB"
+      config:
+        cradle:
+          cabal:
+            - path: appB/src
+              component: appB:lib
+              project-file: cabal.project.8.10.7


### PR DESCRIPTION
Add parser tests for non-standard `cabal.project` file locations
Add bios tests for projects with non-standard `cabal.project` file locations
Follows the same structure as `stackYaml` feature for stack cradles.

Fixes #263