### PR TITLE
Bump upper bound for aeson to <2.2

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -150,7 +150,7 @@ Library
   autogen-modules:      Paths_hie_bios
   Build-Depends:
                         base                 >= 4.8 && < 5,
-                        aeson                >= 1.4.5 && < 2.1,
+                        aeson                >= 1.4.5 && < 2.2,
                         base16-bytestring    >= 0.1.1 && < 1.1,
                         bytestring           >= 0.10.8 && < 0.12,
                         co-log-core          ^>= 0.3.0,


### PR DESCRIPTION
Fixes #358 

Tested via `cabal build --constraint "aeson==2.1.0.0` and `cabal test --constraint "aeson==2.1.0.0"`