### PR TITLE
Add minimum bound on aeson

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -150,7 +150,7 @@ Library
   autogen-modules:      Paths_hie_bios
   Build-Depends:
                         base                 >= 4.8 && < 5,
-                        aeson                >= 1.4.5 && < 2.2,
+                        aeson                >= 2.0 && < 2.2,
                         base16-bytestring    >= 0.1.1 && < 1.1,
                         bytestring           >= 0.10.8 && < 0.12,
                         co-log-core          ^>= 0.3.0,


### PR DESCRIPTION
hie-bios 0.10.0.0 needs a revision on hackage
