### PR TITLE
Add logs over commands

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -75,7 +75,7 @@ main = do
       logger = L.cmap printLog L.logStringStderr
 
     res <- case cmd of
-      Check targetFiles -> checkSyntax logger cradle targetFiles
+      Check targetFiles -> checkSyntax logger logger cradle targetFiles
       Debug files -> case files of
         [] -> debugInfo logger (cradleRootDir cradle) cradle
         fp -> debugInfo logger fp cradle

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -215,6 +215,7 @@ test-suite bios-tests
   default-language: Haskell2010
   build-depends:
       base,
+      co-log-core,
       extra,
       transformers,
       tasty,
@@ -223,6 +224,7 @@ test-suite bios-tests
       hie-bios,
       filepath,
       directory,
+      prettyprinter,
       temporary,
       tagged,
       ghc

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -13,6 +13,7 @@ import System.FilePath
 import System.Environment (lookupEnv)
 
 import qualified Crypto.Hash.SHA1 as H
+import Colog.Core (LogAction, WithSeverity)
 import qualified Data.ByteString.Char8 as B
 import Data.ByteString.Base16
 import Data.List
@@ -67,18 +68,20 @@ makeTargetIdAbsolute _ tid = tid
 --
 --
 -- Obtains libdir by calling 'runCradleGhc' on the provided cradle.
-getRuntimeGhcLibDir :: Cradle a
+getRuntimeGhcLibDir :: LogAction IO (WithSeverity Log)
+                    -> Cradle a
                     -> IO (CradleLoadResult FilePath)
-getRuntimeGhcLibDir cradle = fmap (fmap trim) $
-      runGhcCmd (cradleOptsProg cradle) ["--print-libdir"]
+getRuntimeGhcLibDir l cradle = fmap (fmap trim) $
+      runGhcCmd (cradleOptsProg cradle) l ["--print-libdir"]
 
 -- | Gets the version of ghc used when compiling the cradle. It is based off of
 -- 'getRuntimeGhcLibDir'. If it can't work out the verison reliably, it will
 -- return a 'CradleError'
-getRuntimeGhcVersion :: Cradle a
+getRuntimeGhcVersion :: LogAction IO (WithSeverity Log)
+                     -> Cradle a
                      -> IO (CradleLoadResult String)
-getRuntimeGhcVersion cradle =
-  fmap (fmap trim) $ runGhcCmd (cradleOptsProg cradle) ["--numeric-version"]
+getRuntimeGhcVersion l cradle =
+  fmap (fmap trim) $ runGhcCmd (cradleOptsProg cradle) l ["--numeric-version"]
 
 ----------------------------------------------------------------
 

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -2,14 +2,15 @@ module HIE.Bios.Flags (getCompilerOptions) where
 
 import HIE.Bios.Types
 
-import qualified Colog.Core as L
-import Data.Text.Prettyprint.Doc
+import Colog.Core (LogAction (..), WithSeverity (..), Severity (..), (<&))
 
 -- | Initialize the 'DynFlags' relating to the compilation of a single
 -- file or GHC session according to the provided 'Cradle'.
 getCompilerOptions
-  :: L.LogAction IO (L.WithSeverity Log)
+  :: LogAction IO (WithSeverity Log)
   -> FilePath -- The file we are loading it because of
   -> Cradle a
   -> IO (CradleLoadResult ComponentOptions)
-getCompilerOptions l fp cradle = runCradle (cradleOptsProg cradle) l fp
+getCompilerOptions l fp cradle = do
+  l <& LogProcessOutput "invoking build tool to determine build flags (this may take some time depending on the cache)" `WithSeverity` Info
+  runCradle (cradleOptsProg cradle) l fp

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -33,7 +33,7 @@ debugInfo logger fp cradle = unlines <$> do
     res <- getCompilerOptions logger fp cradle
     canonFp <- canonicalizePath fp
     conf <- findConfig canonFp
-    crdl <- findCradle' canonFp
+    crdl <- findCradle' logger canonFp
     ghcLibDir <- getRuntimeGhcLibDir cradle
     ghcVer <- getRuntimeGhcVersion cradle
     case res of
@@ -84,19 +84,19 @@ findConfig fp = findCradle fp >>= \case
 
 ----------------------------------------------------------------
 
-cradleInfo :: [FilePath] -> IO String
-cradleInfo [] = return "No files given"
-cradleInfo args =
+cradleInfo :: LogAction IO (WithSeverity Log) -> [FilePath] -> IO String
+cradleInfo _ [] = return "No files given"
+cradleInfo l args =
   fmap unlines $ forM args $ \fp -> do
     fp' <- canonicalizePath fp
-    (("Cradle for \"" ++ fp' ++ "\": ") ++)  <$> findCradle' fp'
+    (("Cradle for \"" ++ fp' ++ "\": ") ++)  <$> findCradle' l fp'
 
-findCradle' :: FilePath -> IO String
-findCradle' fp =
+findCradle' :: LogAction IO (WithSeverity Log) -> FilePath -> IO String
+findCradle' l fp =
   findCradle fp >>= \case
     Just yaml -> do
-      crdl <- loadCradle yaml
+      crdl <- loadCradle l yaml
       return $ show crdl
     Nothing -> do
-      crdl <- loadImplicitCradle fp :: IO (Cradle Void)
+      crdl <- loadImplicitCradle l fp :: IO (Cradle Void)
       return $ show crdl

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -33,9 +33,9 @@ debugInfo logger fp cradle = unlines <$> do
     res <- getCompilerOptions logger fp cradle
     canonFp <- canonicalizePath fp
     conf <- findConfig canonFp
-    crdl <- findCradle' logger canonFp
-    ghcLibDir <- getRuntimeGhcLibDir cradle
-    ghcVer <- getRuntimeGhcVersion cradle
+    crdl <- findCradle' canonFp
+    ghcLibDir <- getRuntimeGhcLibDir logger cradle
+    ghcVer <- getRuntimeGhcVersion logger cradle
     case res of
       CradleSuccess (ComponentOptions gopts croot deps) -> do
         return [
@@ -84,19 +84,19 @@ findConfig fp = findCradle fp >>= \case
 
 ----------------------------------------------------------------
 
-cradleInfo :: LogAction IO (WithSeverity Log) -> [FilePath] -> IO String
-cradleInfo _ [] = return "No files given"
-cradleInfo l args =
+cradleInfo :: [FilePath] -> IO String
+cradleInfo [] = return "No files given"
+cradleInfo args =
   fmap unlines $ forM args $ \fp -> do
     fp' <- canonicalizePath fp
-    (("Cradle for \"" ++ fp' ++ "\": ") ++)  <$> findCradle' l fp'
+    (("Cradle for \"" ++ fp' ++ "\": ") ++)  <$> findCradle' fp'
 
-findCradle' :: LogAction IO (WithSeverity Log) -> FilePath -> IO String
-findCradle' l fp =
+findCradle' :: FilePath -> IO String
+findCradle' fp =
   findCradle fp >>= \case
     Just yaml -> do
-      crdl <- loadCradle l yaml
+      crdl <- loadCradle yaml
       return $ show crdl
     Nothing -> do
-      crdl <- loadImplicitCradle l fp :: IO (Cradle Void)
+      crdl <- loadImplicitCradle fp :: IO (Cradle Void)
       return $ show crdl

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -62,7 +62,7 @@ data CradleAction a = CradleAction {
                       -- ^ Name of the action.
                       , runCradle     :: L.LogAction IO (L.WithSeverity Log) -> FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
-                      , runGhcCmd :: [String] -> IO (CradleLoadResult String)
+                      , runGhcCmd     :: L.LogAction IO (L.WithSeverity Log) -> [String] -> IO (CradleLoadResult String)
                       -- ^ Executes the @ghc@ binary that is usually used to
                       -- build the cradle. E.g. for a cabal cradle this should be
                       -- equivalent to @cabal exec ghc -- args@

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -81,6 +81,7 @@ import HIE.Bios.Ghc.Api
 import qualified HIE.Bios.Ghc.Gap as G
 import HIE.Bios.Ghc.Load
 import HIE.Bios.Types
+import Prettyprinter
 import System.Directory
 import System.FilePath
 import System.IO.Temp

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -67,6 +67,7 @@ module Utils (
   findCradleForModuleM,
 ) where
 
+import qualified Colog.Core as L
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.State
@@ -274,15 +275,19 @@ loadRuntimeGhcLibDir :: TestM ()
 loadRuntimeGhcLibDir = do
   crd <- askCradle
   step "Load run-time ghc libdir"
-  libdirRes <- liftIO $ getRuntimeGhcLibDir crd
+  libdirRes <- liftIO $ getRuntimeGhcLibDir testLogger crd
   setLibDirResult libdirRes
 
 loadRuntimeGhcVersion :: TestM ()
 loadRuntimeGhcVersion = do
   crd <- askCradle
   step "Load run-time ghc version"
-  ghcVersionRes <- liftIO $ getRuntimeGhcVersion crd
+  ghcVersionRes <- liftIO $ getRuntimeGhcVersion testLogger crd
   setGhcVersionResult ghcVersionRes
+
+testLogger :: forall a . Pretty a => L.LogAction IO (L.WithSeverity a)
+testLogger = L.cmap printLog L.logStringStderr
+  where printLog (L.WithSeverity l sev) = "[" ++ show sev ++ "] " ++ show (pretty l)
 
 inCradleRootDir :: TestM a -> TestM a
 inCradleRootDir act = do


### PR DESCRIPTION
I'm tackling #372 with a twist:

* Long running command is at `INFO`
* Commands per se are at `DEBUG` level

I think it gives enough feedback for day-to-day use, but allows to have a more verbose if needed.

Regarding design, it introduces a lot of burden, I wonder if I'd better to integrate it in `Cradle`.

WDYT?