### PR TITLE
Relax lower bounds for aeson and prettyprinter

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -150,7 +150,7 @@ Library
   autogen-modules:      Paths_hie_bios
   Build-Depends:
                         base                 >= 4.8 && < 5,
-                        aeson                >= 1.5 && < 2.2,
+                        aeson                >= 1.4.4 && < 2.2,
                         base16-bytestring    >= 0.1.1 && < 1.1,
                         bytestring           >= 0.10.8 && < 0.12,
                         co-log-core          ^>= 0.3.0,

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -162,7 +162,7 @@ Library
                         filepath             >= 1.4.1 && < 1.5,
                         time                 >= 1.8.0 && < 1.13,
                         extra                >= 1.6.14 && < 1.8,
-                        prettyprinter        ^>= 1.7.0,
+                        prettyprinter        ^>= 1.6 || ^>= 1.7.0,
                         process              >= 1.6.1 && < 1.7,
                         ghc                  >= 8.6.1 && < 9.5,
                         transformers         >= 0.5.2 && < 0.7,


### PR DESCRIPTION
This enables building HLS with stackage LTS 16, which is still important for us. 

I tested this with:

    cabal build --constraint "aeson ==1.4.4.0" --constraint "prettyerinter ==1.6.2" -w ghc-8.8

I will need a Hackage revision please @fendor 