### PR TITLE
Fix import and non-canonical instance warnings

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -6,7 +6,7 @@ module Main where
 import Control.Monad ( forM )
 import qualified Colog.Core as L
 import Data.Version (showVersion)
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Options.Applicative
 import System.Directory (getCurrentDirectory)
 import System.IO (stdout, hSetEncoding, utf8)

--- a/src/HIE/Bios/Config/YAML.hs
+++ b/src/HIE/Bios/Config/YAML.hs
@@ -29,8 +29,7 @@ import           Data.Aeson.KeyMap   (keys)
 import qualified Data.HashMap.Strict as Map
 import qualified Data.Text           as T
 #endif
-import           Data.Aeson.Types    (Object, Parser, Value (Null),
-                                      typeMismatch)
+import           Data.Aeson.Types    (Parser, typeMismatch)
 import qualified Data.Char           as C (toLower)
 import           Data.List           ((\\))
 import           GHC.Generics        (Generic)

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -14,7 +14,6 @@ import qualified GHC as G
 
 #if __GLASGOW_HASKELL__ >= 900
 import qualified GHC.Driver.Main as G
-import qualified GHC.Driver.Make as G
 #else
 import qualified HscMain as G
 import qualified GhcMake as G

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -19,7 +19,6 @@ import qualified DynFlags as G
 import Control.Exception
 import Control.Monad.IO.Class
 import Colog.Core (LogAction (..), WithSeverity (..), Severity (..), (<&), cmap)
-import Data.Text.Prettyprint.Doc
 
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Ghc.Logger
@@ -27,6 +26,8 @@ import HIE.Bios.Types hiding (Log (..))
 import qualified HIE.Bios.Types as T
 import qualified HIE.Bios.Ghc.Load as Load
 import HIE.Bios.Environment
+
+import Prettyprinter
 
 import System.IO.Unsafe (unsafePerformIO)
 import qualified HIE.Bios.Ghc.Gap as Gap

--- a/src/HIE/Bios/Ghc/Gap.hs
+++ b/src/HIE/Bios/Ghc/Gap.hs
@@ -146,9 +146,6 @@ import qualified GHC.Tc.Types as Tc
 import GHC.Utils.Outputable
 import qualified GHC.Utils.Ppr as Ppr
 #endif
-#if __GLASGOW_HASKELL__ >= 900
-import GHC.Unit.Types (UnitId)
-#endif
 
 #if __GLASGOW_HASKELL__ >= 900
 import qualified GHC.Driver.Main as G

--- a/src/HIE/Bios/Ghc/Gap.hs
+++ b/src/HIE/Bios/Ghc/Gap.hs
@@ -155,6 +155,10 @@ import qualified HscMain as G
 import qualified GhcMake as G
 #endif
 
+#if (__GLASGOW_HASKELL__ == 901) || __GLASGOW_HASKELL__ >= 941
+import GHC.Unit.Types (UnitId)
+#endif 
+
 ghcVersion :: String
 ghcVersion = VERSION_ghc
 

--- a/src/HIE/Bios/Ghc/Load.hs
+++ b/src/HIE/Bios/Ghc/Load.hs
@@ -11,7 +11,6 @@ import Control.Monad.IO.Class
 
 import Data.List
 import Data.Time.Clock
-import Data.Text.Prettyprint.Doc
 import Data.IORef
 
 import GHC
@@ -19,14 +18,14 @@ import qualified GHC as G
 
 #if __GLASGOW_HASKELL__ >= 900
 import qualified GHC.Driver.Main as G
-import qualified GHC.Driver.Make as G
 #else
 import qualified GhcMake as G
 import qualified HscMain as G
 #endif
 
 import qualified HIE.Bios.Ghc.Gap as Gap
-import GHC.Fingerprint
+
+import Prettyprinter
 
 data Log =
   LogLoaded FilePath FilePath

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -122,11 +122,6 @@ instance (Monad m, Applicative m) => Applicative (CradleLoadResultT m) where
                 CradleNone -> pure CradleNone
 
 instance Monad m => Monad (CradleLoadResultT m) where
-#if !(MIN_VERSION_base(4,8,0))
-  return = CradleLoadResultT . return . CradleSuccess
-  {-# INLINE return #-}
-#endif 
-
   x >>= f = CradleLoadResultT $ do
     val <- runCradleResultT x
     case val of


### PR DESCRIPTION
This PR has a few changes that fix GHC warnings when building `lib:hie-bios` and `exe:hie-bios`:

- Removes `Data.Text.Prettyprint.Doc` imports in favor of the `Prettyprinter` module. The `Data.Text.Prettyprint.Doc` module has been deprecated since `prettyprinter-1.7.0`.

- Removes any redundant imports reported by `-Wunused-imports`.

- Encloses the non-canonical `return` definition specified for `CradleLoadResultT` in `MIN_VERSION_base(4,8,0)`, fixing the `-Wnoncanonical-monad-instances` warning.

I expect some of the `prettyprinter` and redundant imports are actually necessary for backward compatibility. I'm happy to add the correct `#if` directives to silence these warning if that is the case.