### PR TITLE
Better support for multi component projects

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -165,6 +165,7 @@ Library
                         ghc                  >= 8.6.1 && < 9.5,
                         transformers         >= 0.5.2 && < 0.7,
                         temporary            >= 1.2 && < 1.4,
+                        template-haskell,
                         text                 >= 1.2.3 && < 2.1,
                         unix-compat          >= 0.5.1 && < 0.7,
                         unordered-containers >= 0.2.9 && < 0.3,

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -167,9 +167,13 @@ makeDynFlagsAbsolute root df =
         map (Gap.overPkgDbRef makeAbs) (G.packageDBFlags df)
     }
   where
-    makeAbs = case G.workingDirectory df of
-      Nothing -> (root </>)
-      Just fp -> ((root </> fp) </>)
+    makeAbs =
+#if __GLASGOW_HASKELL__ >= 903
+      case G.workingDirectory df of
+        Just fp -> ((root </> fp) </>)
+        Nothing ->
+#endif
+          (root </>)
 
 -- --------------------------------------------------------
 

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -159,7 +159,7 @@ addCmdOpts cmdOpts df1 = do
 -- | Make filepaths in the given 'DynFlags' absolute.
 -- This makes the 'DynFlags' independent of the current working directory.
 makeDynFlagsAbsolute :: FilePath -> G.DynFlags -> G.DynFlags
-makeDynFlagsAbsolute work_dir df =
+makeDynFlagsAbsolute root df =
   Gap.mapOverIncludePaths makeAbs
   $ df
     { G.importPaths = map makeAbs (G.importPaths df)
@@ -167,7 +167,9 @@ makeDynFlagsAbsolute work_dir df =
         map (Gap.overPkgDbRef makeAbs) (G.packageDBFlags df)
     }
   where
-    makeAbs = (work_dir </>)
+    makeAbs = case G.workingDirectory df of
+      Nothing -> (root </>)
+      Just fp -> ((root </> fp) </>)
 
 -- --------------------------------------------------------
 

--- a/src/HIE/Bios/Wrappers.hs
+++ b/src/HIE/Bios/Wrappers.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE CPP #-}
 module HIE.Bios.Wrappers (cabalWrapper, cabalWrapperHs) where
 
-import Data.FileEmbed hiding (makeRelativeToProject)
+import Data.FileEmbed
+#if __GLASGOW_HASKELL__ >= 903
+  hiding (makeRelativeToProject)
+#endif
 import Language.Haskell.TH.Syntax
 
 cabalWrapper :: String

--- a/src/HIE/Bios/Wrappers.hs
+++ b/src/HIE/Bios/Wrappers.hs
@@ -2,11 +2,12 @@
 {-# LANGUAGE QuasiQuotes #-}
 module HIE.Bios.Wrappers (cabalWrapper, cabalWrapperHs) where
 
-import Data.FileEmbed
+import Data.FileEmbed hiding (makeRelativeToProject)
+import Language.Haskell.TH.Syntax
 
 cabalWrapper :: String
-cabalWrapper = $(embedStringFile "wrappers/cabal")
+cabalWrapper = $(makeRelativeToProject "wrappers/cabal" >>= embedStringFile)
 
 cabalWrapperHs :: String
-cabalWrapperHs = $(embedStringFile "wrappers/cabal.hs")
+cabalWrapperHs = $(makeRelativeToProject "wrappers/cabal.hs" >>= embedStringFile)
 


### PR DESCRIPTION
1. Take the working directory of the current component into account when making DynFlags absolute
2. Allow hie-bios itself to be loaded into a multi component session by making the location of the embedded file
   relative to the working directory of the project.
