### PR TITLE
Update GitHub CI to include latest version of major ghc versions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on:
   pull_request:
     branches:
-      - '**'
+      - "**"
   push:
     branches:
       - master
@@ -15,74 +15,90 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.4.2', '9.4.1', '9.2.4', '9.2.1', '9.0.2', '8.10.7', '8.8.4', '8.6.5']
+        ghc: ["9.4.4", "9.2.5", "9.0.2", "8.10.7"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v3
-    - id:   extra-ghc
-      uses: haskell/actions/setup@v2
-      with:
-        ghc-version: '8.10.7'
+      - uses: actions/checkout@v3
+      - id: extra-ghc
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: "8.10.7"
 
-    - uses: haskell/actions/setup@v2
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.8.1.0'
-        enable-stack: true
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: "3.8.1.0"
+          enable-stack: true
 
-    - name: Print extra ghc version
-      run: ghc-8.10.7 --version
+      - name: Print extra ghc version
+        run: ghc-8.10.7 --version
 
-    - name: Print normal ghc version
-      run: ghc --version
+      - name: Print normal ghc version
+        run: ghc --version
 
-    - name: Instruct stack to use system ghc if possible
-      run: stack config set system-ghc --global true
+      - name: Instruct stack to use system ghc if possible
+        run: stack config set system-ghc --global true
 
-    - name: Cache Cabal
-      uses: actions/cache@v3.2.3
-      with:
-        path: ~/.cabal
-        key: ${{ runner.OS }}-${{ matrix.ghc }}-cabal-0
+      - name: Update cabal package index
+        run: cabal v2-update
 
-    - run: cabal update
-    - name: Build
-      run: cabal build
-    - name: Test Parser
-      run: cabal test parser-tests --test-show-details=direct
-    - name: Test Bios
-      # Run all tests in the project
-      run: cabal test bios-tests --test-show-details=direct --test-options="--ignore-tool-deps"
+      - name: Generate freeze file for cache
+        run: cabal v2-freeze
+
+      - name: Cache Cabal
+        uses: actions/cache@v3.2.3
+        with:
+          path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+
+      - name: Build Dependencies
+        run: cabal v2-build --only-dependencies
+
+      - name: Build Hie-Bios
+        run: cabal v2-build
+
+      - name: Test Parser
+        run: cabal v2-test parser-tests --test-show-details=direct
+
+      - name: Test Bios
+        # Run all tests in the project
+        run: cabal v2-test bios-tests --test-show-details=direct --test-options="--ignore-tool-deps"
+
+      - name: Generate Haddock
+        run: cabal v2-haddock
 
   sdist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: haskell/actions/setup@v2
-    - name: Check
-      run: cabal check
-    - name: Generate sdist
-      run: cabal sdist
-    - uses: actions/upload-artifact@v3
-      with:
-        name: 'sdist'
-        path: dist-newstyle/sdist/hie-bios*.tar.gz
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2
+      - name: Check
+        run: cabal check
+      - name: Generate sdist
+        run: cabal sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "sdist"
+          path: dist-newstyle/sdist/hie-bios*.tar.gz
 
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: ludeeus/action-shellcheck@master
-      with:
-        ignore: tests
+      - uses: actions/checkout@v3
+      - uses: ludeeus/action-shellcheck@master
+        with:
+          ignore: tests
 
   windows-wrapper:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: haskell/actions/setup@v2
-      with:
-        ghc-version: ${{ matrix.ghc }}
-    - name: Compile Windows wrapper
-      run: ghc -hide-all-packages -package base -package directory -package process -Wall -Werror wrappers/cabal.hs -o CabalWrapper
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - name: Compile Windows wrapper
+        run: ghc -hide-all-packages -package base -package directory -package process -Wall -Werror wrappers/cabal.hs -o CabalWrapper

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -125,7 +125,7 @@ Extra-Source-Files:     ChangeLog.md
                         tests/projects/stack-with-yaml/stack-with-yaml.cabal
                         tests/projects/stack-with-yaml/src/Lib.hs
 
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.1 || ==9.2.4
+tested-with: GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.4
 
 Library
   Default-Language:     Haskell2010

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -303,8 +303,10 @@ stackYaml resolver pkgs = unlines
 
 stackYamlResolver :: String
 stackYamlResolver =
-#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,2,1,0)))
-  "nightly-2022-09-11" -- GHC 9.2.4
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,4,1,0)))
+  "nightly-2023-01-23" -- GHC 9.4.4
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,2,1,0)))
+  "lts-20.8" -- GHC 9.2.5
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,0,1,0)))
   "lts-19.22" -- GHC 9.0.2
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,10,7,0)))
@@ -382,10 +384,10 @@ ignoreToolTests = Tasty.TestManager [Tasty.Option (Proxy :: Proxy IgnoreToolDeps
 
 ignoreOnUnsupportedGhc :: TestTree -> TestTree
 ignoreOnUnsupportedGhc tt =
-#if (defined(MIN_VERSION_GLASGOW_HASKELL) && MIN_VERSION_GLASGOW_HASKELL(9,4,0,0))
-  ignoreTestBecause "Not supported on GHC >= 9.4"
-#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && MIN_VERSION_GLASGOW_HASKELL(9,2,1,0) && !MIN_VERSION_GLASGOW_HASKELL(9,2,4,0))
-  ignoreTestBecause "Not supported on GHC >= 9.2.1 && < 9.2.4"
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && MIN_VERSION_GLASGOW_HASKELL(9,4,1,0 && !MIN_VERSION_GLASGOW_HASKELL(9,4,4,0)))
+  ignoreTestBecause "Not supported on GHC >= 9.4 && < 9.4.4"
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && MIN_VERSION_GLASGOW_HASKELL(9,2,1,0) && !MIN_VERSION_GLASGOW_HASKELL(9,2,5,0))
+  ignoreTestBecause "Not supported on GHC >= 9.2.1 && < 9.2.5"
 #endif
   tt
 


### PR DESCRIPTION
Fix CI caching.
Only build the latest major versions of GHC.