### PR TITLE
Rename project-file to cabalProject in hie.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,21 +316,21 @@ cradle:
 This way we specified which component needs to be compiled given a certain source file for our whole project.
 
 Some projects have multiple `cabal.project` files for multiple versions of ghc or development options. In this case you
-can specify an alternate relative file to use by using the `project-file` option. The path is relative to the
+can specify an alternate relative file to use by using the `cabalProject` option. The path is relative to the
 `hie.yaml`.
 
 ```yaml
 cradle:
   cabal:
-    project-file: "./cabal.project.dev"
+    cabalProject: "./cabal.project.dev"
 ```
 
-We can combine the `project-file` field with `components`:
+We can combine the `cabalProject` field with `components`:
 
 ```yaml
 cradle:
   cabal:
-    project-file: "./cabal.project.dev"
+    cabalProject: "./cabal.project.dev"
     components:
     - path: "./src"
       component: "lib:hie-bios"

--- a/src/HIE/Bios/Config/YAML.hs
+++ b/src/HIE/Bios/Config/YAML.hs
@@ -108,9 +108,9 @@ data CabalConfig
 
 instance FromJSON CabalConfig where
   parseJSON v@(Array _)     = CabalConfig Nothing . ManyComponents <$> parseJSON v
-  parseJSON v@(Object obj)  = (checkObjectKeys ["project-file", "component", "components"] obj)
+  parseJSON v@(Object obj)  = (checkObjectKeys ["cabalProject", "component", "components"] obj)
                                 *> (CabalConfig
-                                  <$> obj .:? "project-file"
+                                  <$> obj .:? "cabalProject"
                                   <*> parseJSON v)
   parseJSON Null            = pure $ CabalConfig Nothing NoComponent
   parseJSON v               = typeMismatch "CabalConfig" v
@@ -123,11 +123,11 @@ data CabalComponent
 
 instance FromJSON CabalComponent where
   parseJSON =
-    let parseCabalComponent obj = checkObjectKeys ["path", "component", "project-file"] obj
+    let parseCabalComponent obj = checkObjectKeys ["path", "component", "cabalProject"] obj
                                     *> (CabalComponent
                                           <$> obj .: "path"
                                           <*> obj .: "component"
-                                          <*> obj .:? "project-file"
+                                          <*> obj .:? "cabalProject"
                                         )
      in withObject "CabalComponent" parseCabalComponent
 

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -853,11 +853,11 @@ stackAction workDir mc syaml l _fp = do
   -- Same wrapper works as with cabal
   wrapper_fp <- withGhcWrapperTool l ghcProcArgs workDir
   (ex1, _stdo, stde, [(_, maybeArgs)]) <-
-    readProcessWithOutputs [hie_bios_output] l workDir 
+    readProcessWithOutputs [hie_bios_output] l workDir
       $ stackProcess syaml
           $  ["repl", "--no-nix-pure", "--with-ghc", wrapper_fp]
           <> [ comp | Just comp <- [mc] ]
-                      
+
   (ex2, pkg_args, stdr, _) <-
     readProcessWithOutputs [hie_bios_output] l workDir
       $ stackProcess syaml ["path", "--ghc-package-path"]

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -196,7 +196,7 @@ cabalTestCases extraGhcDep =
         loadRuntimeGhcVersion
         assertGhcVersionIs extraGhcVersion
     ]
-  , testGroup "Cabal project-file"
+  , testGroup "Cabal cabalProject"
     [ testCaseSteps "cabal-with-project, options propagated" $ runTestEnv "cabal-with-project" $ do
         opts <- cabalLoadOptions "src/MyLib.hs"
         liftIO $ do

--- a/tests/configs/cabal-with-both.yaml
+++ b/tests/configs/cabal-with-both.yaml
@@ -1,4 +1,4 @@
 cradle:
   cabal:
-    project-file: "cabal.project.8.10.7"
+    cabalProject: "cabal.project.8.10.7"
     component: "hie-bios:hie"

--- a/tests/configs/cabal-with-project.yaml
+++ b/tests/configs/cabal-with-project.yaml
@@ -1,3 +1,3 @@
 cradle:
   cabal:
-    project-file: "cabal.project.8.10.7"
+    cabalProject: "cabal.project.8.10.7"

--- a/tests/configs/multi-cabal-with-project.yaml
+++ b/tests/configs/multi-cabal-with-project.yaml
@@ -1,6 +1,6 @@
 cradle:
   cabal:
-    project-file: "cabal.project.8.10.7"
+    cabalProject: "cabal.project.8.10.7"
     components:
       - path: "./src"
         component: "lib:hie-bios"

--- a/tests/projects/cabal-with-ghc-and-project/hie.yaml
+++ b/tests/projects/cabal-with-ghc-and-project/hie.yaml
@@ -1,3 +1,3 @@
 cradle:
   cabal:
-    project-file: cabal.project.8.10.7
+    cabalProject: cabal.project.8.10.7

--- a/tests/projects/cabal-with-project/hie.yaml
+++ b/tests/projects/cabal-with-project/hie.yaml
@@ -1,3 +1,3 @@
 cradle:
   cabal:
-    project-file: cabal.project.8.10.7
+    cabalProject: cabal.project.8.10.7

--- a/tests/projects/multi-cabal-with-project/hie.yaml
+++ b/tests/projects/multi-cabal-with-project/hie.yaml
@@ -6,11 +6,11 @@ cradle:
           cabal:
             - path: appA/src
               component: appA:lib
-              project-file: cabal.project.8.10.7
+              cabalProject: cabal.project.8.10.7
     - path: "appB"
       config:
         cradle:
           cabal:
             - path: appB/src
               component: appB:lib
-              project-file: cabal.project.8.10.7
+              cabalProject: cabal.project.8.10.7


### PR DESCRIPTION
This is consistent with the name 'stackYaml' for stack cradles. Unfortunate naming, but consistency beats the potential generalisation.

Follow up to #403 