### PR TITLE
Multi Component cabal support

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -84,7 +84,7 @@ main = do
         [] -> error "too few arguments"
         _ -> do
           res <- forM files $ \fp -> do
-                  res <- getCompilerOptions logger fp cradle
+                  res <- getCompilerOptions logger fp [] cradle
                   case res of
                       CradleFail (CradleError _deps _ex err) ->
                         return $ "Failed to show flags for \""

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -63,28 +63,28 @@ main = do
     hSetEncoding stdout utf8
     cwd <- getCurrentDirectory
     cmd <- execParser progInfo
-    cradle <-
-        -- find cradle does a takeDirectory on the argument, so make it into a file
-        findCradle (cwd </> "File.hs") >>= \case
-          Just yaml -> loadCradle yaml
-          Nothing -> loadImplicitCradle (cwd </> "File.hs")
-
     let
       printLog (L.WithSeverity l sev) = "[" ++ show sev ++ "] " ++ show (pretty l)
       logger :: forall a . Pretty a => L.LogAction IO (L.WithSeverity a)
       logger = L.cmap printLog L.logStringStderr
 
+    cradle <-
+        -- find cradle does a takeDirectory on the argument, so make it into a file
+        findCradle (cwd </> "File.hs") >>= \case
+          Just yaml -> loadCradle logger yaml
+          Nothing -> loadImplicitCradle logger (cwd </> "File.hs")
+
     res <- case cmd of
-      Check targetFiles -> checkSyntax logger logger cradle targetFiles
+      Check targetFiles -> checkSyntax logger cradle targetFiles
       Debug files -> case files of
-        [] -> debugInfo logger (cradleRootDir cradle) cradle
-        fp -> debugInfo logger fp cradle
+        [] -> debugInfo (cradleRootDir cradle) cradle
+        fp -> debugInfo fp cradle
       Flags files -> case files of
         -- TODO force optparse to acquire one
         [] -> error "too few arguments"
         _ -> do
           res <- forM files $ \fp -> do
-                  res <- getCompilerOptions logger fp [] cradle
+                  res <- getCompilerOptions fp [] cradle
                   case res of
                       CradleFail (CradleError _deps _ex err) ->
                         return $ "Failed to show flags for \""
@@ -97,7 +97,7 @@ main = do
                       CradleNone -> return $ "No flags/None Cradle: component " ++ fp ++ " should not be loaded"
           return (unlines res)
       ConfigInfo files -> configInfo files
-      CradleInfo files -> cradleInfo files
+      CradleInfo files -> cradleInfo logger files
       Root    -> rootInfo cradle
       Version -> return progVersion
     putStr res

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -784,6 +784,7 @@ cabalAction (ResolvedCradles root cs vs) workDir mc l projectFile fp fps = do
           [] -> [fromMaybe (fixTargetPath fp) mc]
           -- Start a multi-component session with all the old files
           _ -> "--keep-temp-files"
+             : "--enable-multi-repl"
              : [fromMaybe (fixTargetPath fp) mc]
             ++ [fromMaybe (fixTargetPath old_fp) old_mc
                | old_fp <- fps

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE RecordWildCards #-}
 module HIE.Bios.Cradle (
       findCradle
     , loadCradle
@@ -69,6 +71,10 @@ import qualified HIE.Bios.Ghc.Gap as Gap
 import GHC.Fingerprint (fingerprintString)
 import GHC.ResponseFile (escapeArgs)
 
+import Data.Version
+import System.IO.Unsafe (unsafeInterleaveIO)
+import Text.ParserCombinators.ReadP (readP_to_S)
+
 ----------------------------------------------------------------
 
 -- | Given root\/foo\/bar.hs, return root\/hie.yaml, or wherever the yaml file was found.
@@ -86,66 +92,210 @@ loadImplicitCradle :: Show a => FilePath -> IO (Cradle a)
 loadImplicitCradle wfile = do
   let wdir = takeDirectory wfile
   cfg <- runMaybeT (implicitConfig wdir)
-  return $ case cfg of
+  case cfg of
     Just bc -> getCradle absurd bc
-    Nothing -> defaultCradle wdir
+    Nothing -> return $ defaultCradle wdir
 
 -- | Finding 'Cradle'.
 --   Find a cabal file by tracing ancestor directories.
 --   Find a sandbox according to a cabal sandbox config
 --   in a cabal directory.
-loadCradleWithOpts :: (Yaml.FromJSON b) => (b -> Cradle a) -> FilePath -> IO (Cradle a)
+loadCradleWithOpts :: (Yaml.FromJSON b, Show a) => (b -> CradleAction a) -> FilePath -> IO (Cradle a)
 loadCradleWithOpts buildCustomCradle wfile = do
     cradleConfig <- readCradleConfig wfile
-    return $ getCradle buildCustomCradle (cradleConfig, takeDirectory wfile)
+    getCradle buildCustomCradle (cradleConfig, takeDirectory wfile)
 
-getCradle :: (b -> Cradle a) -> (CradleConfig b, FilePath) -> Cradle a
-getCradle buildCustomCradle (cc, wdir) = addCradleDeps cradleDeps $ case cradleType cc of
-    Cabal CabalType{ cabalComponent = mc, cabalProjectFile = prjFile } ->
-      cabalCradle wdir mc (projectConfigFromMaybe wdir prjFile)
-    CabalMulti dc ms ->
-      getCradle buildCustomCradle
-        (CradleConfig cradleDeps
-          (Multi [(p, CradleConfig [] (Cabal $ dc <> c)) | (p, c) <- ms])
-        , wdir)
-    Stack StackType{ stackComponent = mc, stackYaml = syaml} ->
-      stackCradle wdir mc (projectConfigFromMaybe wdir syaml)
-    StackMulti ds ms ->
-      getCradle buildCustomCradle
-        (CradleConfig cradleDeps
-          (Multi [(p, CradleConfig [] (Stack $ ds <> c)) | (p, c) <- ms])
-        , wdir)
- --   Bazel -> rulesHaskellCradle wdir
- --   Obelisk -> obeliskCradle wdir
-    Bios bios deps mbGhc -> biosCradle wdir bios deps mbGhc
-    Direct xs -> directCradle wdir xs
-    None      -> noneCradle wdir
-    Multi ms  -> multiCradle buildCustomCradle wdir ms
-    Other a _ -> buildCustomCradle a
-    where
-      cradleDeps = cradleDependencies cc
-
-addCradleDeps :: [FilePath] -> Cradle a -> Cradle a
-addCradleDeps deps c =
-  c { cradleOptsProg = addActionDeps (cradleOptsProg c) }
+getCradle :: Show a => (b -> CradleAction a) -> (CradleConfig b, FilePath) -> IO (Cradle a)
+getCradle buildCustomCradle (cc, wdir) = do
+    rcs <- canonicalizeResolvedCradles wdir cs
+    resolvedCradlesToCradle buildCustomCradle wdir rcs
   where
-    addActionDeps :: CradleAction a -> CradleAction a
-    addActionDeps ca =
-      ca { runCradle = \l fp ->
-            (cradleLoadResult
-                CradleNone
-                (\err -> CradleFail (err { cradleErrorDependencies = cradleErrorDependencies err `union` deps }))
-                (\(ComponentOptions os' dir ds) -> CradleSuccess (ComponentOptions os' dir (ds `union` deps)))
-            )
-            <$> runCradle ca l fp
-         }
+    cs = resolveCradleTree wdir cc
+
+
+-- | The actual type of action we will be using to process a file
+data ConcreteCradle a
+  = ConcreteCabal CabalType
+  | ConcreteStack StackType
+  | ConcreteBios Callable (Maybe Callable) (Maybe FilePath)
+  | ConcreteDirect [String]
+  | ConcreteNone
+  | ConcreteOther a
+  deriving Show
+
+-- | ConcreteCradle augmented with information on which file the
+-- cradle applies
+data ResolvedCradle a
+ = ResolvedCradle
+ { prefix :: FilePath -- ^ the prefix to match files
+ , cradleDeps :: [FilePath] -- ^ accumulated dependencies
+ , concreteCradle :: ConcreteCradle a
+ } deriving Show
+
+-- | The final cradle config that specifies the cradle for
+-- each prefix we know how to handle
+data ResolvedCradles a
+ = ResolvedCradles
+ { cradleRoot :: FilePath
+ , resolvedCradles :: [ResolvedCradle a] -- ^ In order of decreasing specificity
+ , cradleProgramVersions :: ProgramVersions
+ }
+
+data ProgramVersions =
+  ProgramVersions { cabalVersion  :: Maybe Version
+                  , stackVersion  :: Maybe Version
+                  , ghcVersion    :: Maybe Version
+                  }
+
+makeVersions :: ([String] -> IO (CradleLoadResult String)) -> IO ProgramVersions
+makeVersions ghc = do
+  cabalVersion <- unsafeInterleaveIO getCabalVersion
+  stackVersion <- unsafeInterleaveIO getStackVersion
+  ghcVersion <- unsafeInterleaveIO (getGhcVersion ghc)
+  pure ProgramVersions{..}
+
+getCabalVersion :: IO (Maybe Version)
+getCabalVersion = do
+  let p = proc "cabal" ["--numeric-version"]
+  res <- optional $ readCreateProcessWithExitCode p ""
+  case res of
+    Just (ExitSuccess,stdo,_) ->
+      pure $ versionMaybe stdo
+    _ -> pure Nothing
+
+getStackVersion :: IO (Maybe Version)
+getStackVersion = do
+  let p = proc "stack" ["--numeric-version"]
+  res <- optional $ readCreateProcessWithExitCode p ""
+  case res of
+    Just (ExitSuccess,stdo,_) ->
+      pure $ versionMaybe stdo
+    _ -> pure Nothing
+
+getGhcVersion :: ([String] -> IO (CradleLoadResult String)) -> IO (Maybe Version)
+getGhcVersion ghc = do
+  res <- optional $ ghc ["--numeric-version"]
+  case res of
+    Just (CradleSuccess stdo) ->
+      pure $ versionMaybe stdo
+    _ -> pure Nothing
+
+versionMaybe :: String -> Maybe Version
+versionMaybe xs = case reverse $ readP_to_S parseVersion xs of
+  [] -> Nothing
+  (x:_) -> Just (fst x)
+
+
+addActionDeps :: [FilePath] -> CradleLoadResult ComponentOptions -> CradleLoadResult ComponentOptions
+addActionDeps deps =
+  cradleLoadResult
+      CradleNone
+      (\err -> CradleFail (err { cradleErrorDependencies = cradleErrorDependencies err `union` deps }))
+      (\(ComponentOptions os' dir ds) -> CradleSuccess (ComponentOptions os' dir (ds `union` deps)))
+  
+
+resolvedCradlesToCradle :: Show a => (b -> CradleAction a) -> FilePath -> [ResolvedCradle b] -> IO (Cradle a)
+resolvedCradlesToCradle buildCustomCradle root cs = mdo
+  let run_ghc_cmd l args =
+        -- We're being lazy here and just returning the ghc path for the
+        -- first non-none cradle. This shouldn't matter in practice: all
+        -- sub cradles should be using the same ghc version!
+        case filter (notNoneType . actionName) $ map snd cradleActions of
+          [] -> return CradleNone
+          (act:_) ->
+            runGhcCmd
+              act
+              l
+              args
+  versions <- makeVersions (run_ghc_cmd mempty)
+  let rcs = ResolvedCradles root cs versions
+      cradleActions = [ (c, resolveCradleAction buildCustomCradle rcs root c) | c <- cs ]
+      err_msg fp
+        = ["Multi Cradle: No prefixes matched"
+          , "pwd: " ++ root
+          , "filepath: " ++ fp
+          , "prefixes:"
+          ] ++ [show (prefix pf, actionName cc) | (pf, cc) <- cradleActions]
+  pure $ Cradle
+    { cradleRootDir = root
+    , cradleOptsProg = CradleAction
+      { actionName = multiActionName
+      , runCradle  = \l fp prev -> do
+          absfp <- makeAbsolute fp
+          case selectCradle (prefix . fst) absfp cradleActions of
+            Just (rc, act) -> do
+              addActionDeps (cradleDeps rc) <$> runCradle act l fp prev
+            Nothing -> return $ CradleFail $ CradleError [] ExitSuccess (err_msg fp)
+      , runGhcCmd = run_ghc_cmd
+      }
+    }
+  where
+    multiActionName
+      | all (\c -> isStackCradleConfig c || isNoneCradleConfig c) cs
+      = Types.Stack
+      | all (\c -> isCabalCradleConfig c || isNoneCradleConfig c) cs
+      = Types.Cabal
+      | [True] <- map isBiosCradleConfig $ filter (not . isNoneCradleConfig) cs
+      = Types.Bios
+      | [True] <- map isDirectCradleConfig $ filter (not . isNoneCradleConfig) cs
+      = Types.Direct
+      | otherwise
+      = Types.Multi
+
+    isStackCradleConfig cfg = case concreteCradle cfg of
+      ConcreteStack{} -> True
+      _               -> False
+
+    isCabalCradleConfig cfg = case concreteCradle cfg of
+      ConcreteCabal{} -> True
+      _               -> False
+
+    isBiosCradleConfig cfg = case concreteCradle cfg of
+      ConcreteBios{}  -> True
+      _               -> False
+
+    isDirectCradleConfig cfg = case concreteCradle cfg of
+      ConcreteDirect{} -> True
+      _                -> False
+
+    isNoneCradleConfig cfg = case concreteCradle cfg of
+      ConcreteNone{} -> True
+      _              -> False
+
+    notNoneType Types.None = False
+    notNoneType _ = True
+
+
+resolveCradleAction :: (b -> CradleAction a) -> ResolvedCradles b -> FilePath -> ResolvedCradle b -> CradleAction a
+resolveCradleAction buildCustomCradle cs root cradle =
+  case concreteCradle cradle of
+    ConcreteCabal t -> cabalCradle cs root (cabalComponent t) (projectConfigFromMaybe root (cabalProjectFile t))
+    ConcreteStack t -> stackCradle root (stackComponent t) (projectConfigFromMaybe root (stackYaml t))
+    ConcreteBios bios deps mbGhc -> biosCradle root bios deps mbGhc
+    ConcreteDirect xs -> directCradle root xs
+    ConcreteNone -> noneCradle
+    ConcreteOther a -> buildCustomCradle a
+
+resolveCradleTree :: FilePath -> CradleConfig a -> [ResolvedCradle a]
+resolveCradleTree root (CradleConfig deps tree) = go root deps tree
+  where
+    go pfix deps tree = case tree of
+      Cabal t              -> [ResolvedCradle pfix deps (ConcreteCabal t)]
+      Stack t              -> [ResolvedCradle pfix deps (ConcreteStack t)]
+      Bios bios dcmd mbGhc -> [ResolvedCradle pfix deps (ConcreteBios bios dcmd mbGhc)]
+      Direct xs            -> [ResolvedCradle pfix deps (ConcreteDirect xs)]
+      None                 -> [ResolvedCradle pfix deps ConcreteNone]
+      Other a _            -> [ResolvedCradle pfix deps (ConcreteOther a)]
+      CabalMulti dc xs     -> [ResolvedCradle p    deps (ConcreteCabal (dc <> c)) | (p, c) <- xs ]
+      StackMulti dc xs     -> [ResolvedCradle p    deps (ConcreteStack (dc <> c)) | (p, c) <- xs ]
+      Multi xs             -> concat [ go pfix' (deps ++ deps') tree' | (pfix', CradleConfig deps' tree') <- xs]
 
 -- | Try to infer an appropriate implicit cradle type from stuff we can find in the enclosing directories:
 --   * If a .hie-bios file is found, we can treat this as a @Bios@ cradle
 --   * If a stack.yaml file is found, we can treat this as a @Stack@ cradle
 --   * If a cabal.project or an xyz.cabal file is found, we can treat this as a @Cabal@ cradle
-inferCradleType :: FilePath -> MaybeT IO (CradleType a, FilePath)
-inferCradleType fp =
+inferCradleTree :: FilePath -> MaybeT IO (CradleTree a, FilePath)
+inferCradleTree fp =
        maybeItsBios
    <|> maybeItsStack
    <|> maybeItsCabal
@@ -164,9 +314,9 @@ inferCradleType fp =
   -- maybeItsBazel = (Bazel,) <$> rulesHaskellWorkDir fp
 
 
--- | Wraps up the cradle inferred by @inferCradleType@ as a @CradleConfig@ with no dependencies
+-- | Wraps up the cradle inferred by @inferCradleTree@ as a @CradleConfig@ with no dependencies
 implicitConfig :: FilePath -> MaybeT IO (CradleConfig a, FilePath)
-implicitConfig = (fmap . first) (CradleConfig noDeps) . inferCradleType
+implicitConfig = (fmap . first) (CradleConfig noDeps) . inferCradleTree
   where
   noDeps :: [FilePath]
   noDeps = []
@@ -247,7 +397,7 @@ defaultCradle cur_dir =
     { cradleRootDir = cur_dir
     , cradleOptsProg = CradleAction
         { actionName = Types.Default
-        , runCradle = \_ _ ->
+        , runCradle = \_ _ _ ->
             return (CradleSuccess (ComponentOptions argDynamic cur_dir []))
         , runGhcCmd = \l -> runGhcCmdOnPath l cur_dir
         }
@@ -256,143 +406,69 @@ defaultCradle cur_dir =
 ---------------------------------------------------------------
 -- | The none cradle tells us not to even attempt to load a certain directory
 
-noneCradle :: FilePath -> Cradle a
-noneCradle cur_dir =
-  Cradle
-    { cradleRootDir = cur_dir
-    , cradleOptsProg = CradleAction
-        { actionName = Types.None
-        , runCradle = \_ _ -> return CradleNone
-        , runGhcCmd = \_ _ -> return CradleNone
-        }
-    }
+noneCradle :: CradleAction a
+noneCradle =
+  CradleAction
+      { actionName = Types.None
+      , runCradle = \_ _ _ -> return CradleNone
+      , runGhcCmd = \_ _ -> return CradleNone
+      }
 
 ---------------------------------------------------------------
 -- | The multi cradle selects a cradle based on the filepath
 
-multiCradle :: (b -> Cradle a) -> FilePath -> [(FilePath, CradleConfig b)] -> Cradle a
-multiCradle buildCustomCradle cur_dir cs =
-  Cradle
-    { cradleRootDir  = cur_dir
-    , cradleOptsProg = CradleAction
-        { actionName = multiActionName
-        , runCradle  = \l fp -> makeAbsolute fp >>= multiAction buildCustomCradle cur_dir cs l
-        , runGhcCmd = \l args ->
-            -- We're being lazy here and just returning the ghc path for the
-            -- first non-none cradle. This shouldn't matter in practice: all
-            -- sub cradles should be using the same ghc version!
-            case filter (not . isNoneCradleConfig) $ map snd cs of
-              [] -> return CradleNone
-              (cfg:_) ->
-                runGhcCmd
-                  (cradleOptsProg $ getCradle buildCustomCradle (cfg, cur_dir))
-                  l
-                  args
-        }
-    }
-  where
-    cfgs = map snd cs
+-- Canonicalize the relative paths present in the multi-cradle and
+-- also order the paths by most specific first. In the cradle selection
+-- function we want to choose the most specific cradle possible.
+canonicalizeResolvedCradles :: FilePath -> [ResolvedCradle a] -> IO [ResolvedCradle a]
+canonicalizeResolvedCradles cur_dir cs =
+  sortOn (Down . prefix)
+    <$> mapM (\c -> (\abs -> c {prefix = abs}) <$> makeAbsolute (cur_dir </> prefix c)) cs
 
-    multiActionName
-      | all (\c -> isStackCradleConfig c || isNoneCradleConfig c) cfgs
-      = Types.Stack
-      | all (\c -> isCabalCradleConfig c || isNoneCradleConfig c) cfgs
-      = Types.Cabal
-      | otherwise
-      = Types.Multi
-
-    isStackCradleConfig cfg = case cradleType cfg of
-      Stack{}      -> True
-      StackMulti{} -> True
-      _            -> False
-
-    isCabalCradleConfig cfg = case cradleType cfg of
-      Cabal{}      -> True
-      CabalMulti{} -> True
-      _            -> False
-
-    isNoneCradleConfig cfg = case cradleType cfg of
-      None -> True
-      _    -> False
-
-multiAction
-  ::  forall b a
-  . (b -> Cradle a)
-  -> FilePath
-  -> [(FilePath, CradleConfig b)]
-  -> LogAction IO (WithSeverity Log)
-  -> FilePath
-  -> IO (CradleLoadResult ComponentOptions)
-multiAction buildCustomCradle cur_dir cs l cur_fp =
-    selectCradle =<< canonicalizeCradles
-
-  where
-    err_msg = ["Multi Cradle: No prefixes matched"
-              , "pwd: " ++ cur_dir
-              , "filepath: " ++ cur_fp
-              , "prefixes:"
-              ] ++ [show (pf, cradleType cc) | (pf, cc) <- cs]
-
-    -- Canonicalize the relative paths present in the multi-cradle and
-    -- also order the paths by most specific first. In the cradle selection
-    -- function we want to choose the most specific cradle possible.
-    canonicalizeCradles :: IO [(FilePath, CradleConfig b)]
-    canonicalizeCradles =
-      sortOn (Down . fst)
-        <$> mapM (\(p, c) -> (,c) <$> makeAbsolute (cur_dir </> p)) cs
-
-    selectCradle [] =
-      return (CradleFail (CradleError [] ExitSuccess err_msg))
-    selectCradle ((p, c): css) =
-        if p `isPrefixOf` cur_fp
-          then runCradle
-                  (cradleOptsProg (getCradle buildCustomCradle (c, cur_dir)))
-                  l
-                  cur_fp
-          else selectCradle css
+selectCradle :: (a -> FilePath) -> FilePath -> [a] -> Maybe a
+selectCradle _ _ [] = Nothing
+selectCradle k cur_fp (c: css) =
+    if k c `isPrefixOf` cur_fp
+      then Just c
+      else selectCradle k cur_fp css
 
 
 -------------------------------------------------------------------------
 
-directCradle :: FilePath -> [String] -> Cradle a
-directCradle wdir args =
-  Cradle
-    { cradleRootDir = wdir
-    , cradleOptsProg = CradleAction
-        { actionName = Types.Direct
-        , runCradle = \_ _ ->
-            return (CradleSuccess (ComponentOptions (args ++ argDynamic) wdir []))
-        , runGhcCmd = \l -> runGhcCmdOnPath l wdir
-        }
-    }
+directCradle :: FilePath -> [String] -> CradleAction a
+directCradle wdir args
+  = CradleAction
+      { actionName = Types.Direct
+      , runCradle = \_ _ _ ->
+          return (CradleSuccess (ComponentOptions (args ++ argDynamic) wdir []))
+      , runGhcCmd = \l -> runGhcCmdOnPath l wdir
+      }
+    
 
 -------------------------------------------------------------------------
 
 
 -- | Find a cradle by finding an executable `hie-bios` file which will
 -- be executed to find the correct GHC options to use.
-biosCradle :: FilePath -> Callable -> Maybe Callable -> Maybe FilePath -> Cradle a
-biosCradle wdir biosCall biosDepsCall mbGhc =
-  Cradle
-    { cradleRootDir    = wdir
-    , cradleOptsProg   = CradleAction
-        { actionName = Types.Bios
-        , runCradle = biosAction wdir biosCall biosDepsCall
-        , runGhcCmd = \l args -> readProcessWithCwd l wdir (fromMaybe "ghc" mbGhc) args ""
-        }
-    }
+biosCradle :: FilePath -> Callable -> Maybe Callable -> Maybe FilePath -> CradleAction a
+biosCradle wdir biosCall biosDepsCall mbGhc
+  = CradleAction
+      { actionName = Types.Bios
+      , runCradle = biosAction wdir biosCall biosDepsCall
+      , runGhcCmd = \l args -> readProcessWithCwd l wdir (fromMaybe "ghc" mbGhc) args ""
+      }
 
 biosWorkDir :: FilePath -> MaybeT IO FilePath
 biosWorkDir = findFileUpwards (".hie-bios" ==)
 
-biosDepsAction :: LogAction IO (WithSeverity Log) -> FilePath -> Maybe Callable -> FilePath -> IO [FilePath]
-biosDepsAction l wdir (Just biosDepsCall) fp = do
-  biosDeps' <- callableToProcess biosDepsCall (Just fp)
+biosDepsAction :: LogAction IO (WithSeverity Log) -> FilePath -> Maybe Callable -> FilePath -> [FilePath] -> IO [FilePath]
+biosDepsAction l wdir (Just biosDepsCall) fp _prevs = do
+  biosDeps' <- callableToProcess biosDepsCall (Just fp) -- TODO multi pass the previous files too
   (ex, sout, serr, [(_, args)]) <- readProcessWithOutputs [hie_bios_output] l wdir biosDeps'
   case ex of
     ExitFailure _ ->  error $ show (ex, sout, serr)
     ExitSuccess -> return $ fromMaybe [] args
-biosDepsAction _ _ Nothing _ = return []
+biosDepsAction _ _ Nothing _ _ = return []
 
 biosAction
   :: FilePath
@@ -400,15 +476,16 @@ biosAction
   -> Maybe Callable
   -> LogAction IO (WithSeverity Log)
   -> FilePath
+  -> [FilePath]
   -> IO (CradleLoadResult ComponentOptions)
-biosAction wdir bios bios_deps l fp = do
-  bios' <- callableToProcess bios (Just fp)
+biosAction wdir bios bios_deps l fp fps = do
+  bios' <- callableToProcess bios (Just fp) -- TODO pass all the files instead of listToMaybe
   (ex, _stdo, std, [(_, res),(_, mb_deps)]) <-
     readProcessWithOutputs [hie_bios_output, hie_bios_deps] l wdir bios'
 
   deps <- case mb_deps of
     Just x  -> return x
-    Nothing -> biosDepsAction l wdir bios_deps fp
+    Nothing -> biosDepsAction l wdir bios_deps fp fps
         -- Output from the program should be written to the output file and
         -- delimited by newlines.
         -- Execute the bios action and add dependencies of the cradle.
@@ -436,23 +513,21 @@ projectLocationOrDefault = \case
 
 -- |Cabal Cradle
 -- Works for new-build by invoking `v2-repl`.
-cabalCradle :: FilePath -> Maybe String -> CradleProjectConfig -> Cradle a
-cabalCradle wdir mc projectFile =
-  Cradle
-    { cradleRootDir    = wdir
-    , cradleOptsProg   = CradleAction
-        { actionName = Types.Cabal
-        , runCradle = \l -> runCradleResultT . cabalAction wdir mc l projectFile
-        , runGhcCmd = \l args -> runCradleResultT $ do
-            buildDir <- liftIO $ cabalBuildDir wdir
-            -- Workaround for a cabal-install bug on 3.0.0.0:
-            -- ./dist-newstyle/tmp/environment.-24811: createDirectory: does not exist (No such file or directory)
-            liftIO $ createDirectoryIfMissing True (buildDir </> "tmp")
-            -- Need to pass -v0 otherwise we get "resolving dependencies..."
-            cabalProc <- cabalProcess l projectFile wdir "v2-exec" $ ["ghc", "-v0", "--"] ++ args
-            readProcessWithCwd' l cabalProc ""
-        }
+cabalCradle :: ResolvedCradles b -> FilePath -> Maybe String -> CradleProjectConfig -> CradleAction a
+cabalCradle cs wdir mc projectFile
+  = CradleAction
+    { actionName = Types.Cabal
+    , runCradle = \l fp -> runCradleResultT . cabalAction cs wdir mc l projectFile fp
+    , runGhcCmd = \l args -> runCradleResultT $ do
+        buildDir <- liftIO $ cabalBuildDir wdir
+        -- Workaround for a cabal-install bug on 3.0.0.0:
+        -- ./dist-newstyle/tmp/environment.-24811: createDirectory: does not exist (No such file or directory)
+        liftIO $ createDirectoryIfMissing True (buildDir </> "tmp")
+        -- Need to pass -v0 otherwise we get "resolving dependencies..."
+        cabalProc <- cabalProcess l projectFile wdir "v2-exec" $ ["ghc", "-v0", "--"] ++ args
+        readProcessWithCwd' l cabalProc ""
     }
+    
 
 -- | Execute a cabal process in our custom cache-build directory configured
 -- with the custom ghc executable.
@@ -687,16 +762,39 @@ cabalGhcDirs l cabalProject workDir = do
 
 
 cabalAction
-  :: FilePath
+  :: ResolvedCradles a
+  -> FilePath
   -> Maybe String
   -> LogAction IO (WithSeverity Log)
   -> CradleProjectConfig
   -> FilePath
+  -> [FilePath]
   -> CradleLoadResultT IO ComponentOptions
-cabalAction workDir mc l projectFile fp = do
+cabalAction (ResolvedCradles root cs vs) workDir mc l projectFile fp fps = do
   let
     cabalCommand = "v2-repl"
-    cabalArgs = [fromMaybe (fixTargetPath fp) mc]
+    cabal_version = cabalVersion vs
+    ghc_version = ghcVersion vs
+    cabalArgs = case (cabal_version, ghc_version) of
+      (Just cabal, Just ghc)
+        -- Multi-component supported from cabal-install 3.11
+        -- and ghc 9.4
+        | ghc   >= makeVersion [9,4]
+        , cabal >= makeVersion [3,11]
+        -> case fps of
+          [] -> [fromMaybe (fixTargetPath fp) mc]
+          -- Start a multi-component session with all the old files
+          _ -> "--keep-temp-files"
+             : [fromMaybe (fixTargetPath fp) mc]
+            ++ [fromMaybe (fixTargetPath old_fp) old_mc
+               | old_fp <- fps
+               -- Lookup the component for the old file
+               , Just (ResolvedCradle{concreteCradle = ConcreteCabal ct}) <- [selectCradle prefix old_fp cs]
+               -- Only include this file if the old component is in the same project
+               , (projectConfigFromMaybe root (cabalProjectFile ct)) == projectFile
+               , let old_mc = cabalComponent ct
+               ]
+      _ -> [fromMaybe (fixTargetPath fp) mc]
 
   cabalProc <- cabalProcess l projectFile workDir cabalCommand cabalArgs `modCradleError` \err -> do
       deps <- cabalCradleDependencies projectFile workDir workDir
@@ -788,6 +886,7 @@ cabalWorkDir wdir =
 data CradleProjectConfig
   = NoExplicitConfig
   | ExplicitConfig FilePath
+  deriving Eq
 
 -- | Create an explicit project configuration. Expects a working directory
 -- followed by an optional name of the project configuration.
@@ -807,21 +906,18 @@ stackYamlLocationOrDefault (ExplicitConfig yaml) = yaml
 
 -- | Stack Cradle
 -- Works for by invoking `stack repl` with a wrapper script
-stackCradle :: FilePath -> Maybe String -> CradleProjectConfig -> Cradle a
+stackCradle :: FilePath -> Maybe String -> CradleProjectConfig -> CradleAction a
 stackCradle wdir mc syaml =
-  Cradle
-    { cradleRootDir    = wdir
-    , cradleOptsProg   = CradleAction
-        { actionName = Types.Stack
-        , runCradle = stackAction wdir mc syaml
-        , runGhcCmd = \l args -> runCradleResultT $ do
-            -- Setup stack silently, since stack might print stuff to stdout in some cases (e.g. on Win)
-            -- Issue 242 from HLS: https://github.com/haskell/haskell-language-server/issues/242
-            _ <- readProcessWithCwd_ l wdir "stack" (stackYamlProcessArgs syaml <> ["setup", "--silent"]) ""
-            readProcessWithCwd_ l wdir "stack"
-              (stackYamlProcessArgs syaml <> ["exec", "ghc", "--"] <> args)
-              ""
-        }
+  CradleAction
+    { actionName = Types.Stack
+    , runCradle = stackAction wdir mc syaml
+    , runGhcCmd = \l args -> runCradleResultT $ do
+        -- Setup stack silently, since stack might print stuff to stdout in some cases (e.g. on Win)
+        -- Issue 242 from HLS: https://github.com/haskell/haskell-language-server/issues/242
+        _ <- readProcessWithCwd_ l wdir "stack" (stackYamlProcessArgs syaml <> ["setup", "--silent"]) ""
+        readProcessWithCwd_ l wdir "stack"
+          (stackYamlProcessArgs syaml <> ["exec", "ghc", "--"] <> args)
+          ""
     }
 
 -- | @'stackCradleDependencies' rootDir componentDir@.
@@ -847,8 +943,9 @@ stackAction
   -> CradleProjectConfig
   -> LogAction IO (WithSeverity Log)
   -> FilePath
+  -> [FilePath]
   -> IO (CradleLoadResult ComponentOptions)
-stackAction workDir mc syaml l _fp = do
+stackAction workDir mc syaml l _fp _fps = do
   let ghcProcArgs = ("stack", stackYamlProcessArgs syaml <> ["exec", "ghc", "--"])
   -- Same wrapper works as with cabal
   wrapper_fp <- withGhcWrapperTool l ghcProcArgs workDir

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -68,20 +68,18 @@ makeTargetIdAbsolute _ tid = tid
 --
 --
 -- Obtains libdir by calling 'runCradleGhc' on the provided cradle.
-getRuntimeGhcLibDir :: LogAction IO (WithSeverity Log)
-                    -> Cradle a
+getRuntimeGhcLibDir :: Cradle a
                     -> IO (CradleLoadResult FilePath)
-getRuntimeGhcLibDir l cradle = fmap (fmap trim) $
-      runGhcCmd (cradleOptsProg cradle) l ["--print-libdir"]
+getRuntimeGhcLibDir cradle = fmap (fmap trim) $
+      runGhcCmd (cradleOptsProg cradle) ["--print-libdir"]
 
 -- | Gets the version of ghc used when compiling the cradle. It is based off of
 -- 'getRuntimeGhcLibDir'. If it can't work out the verison reliably, it will
 -- return a 'CradleError'
-getRuntimeGhcVersion :: LogAction IO (WithSeverity Log)
-                     -> Cradle a
+getRuntimeGhcVersion :: Cradle a
                      -> IO (CradleLoadResult String)
-getRuntimeGhcVersion l cradle =
-  fmap (fmap trim) $ runGhcCmd (cradleOptsProg cradle) l ["--numeric-version"]
+getRuntimeGhcVersion cradle =
+  fmap (fmap trim) $ runGhcCmd (cradleOptsProg cradle) ["--numeric-version"]
 
 ----------------------------------------------------------------
 

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -8,9 +8,10 @@ import Colog.Core (LogAction (..), WithSeverity (..), Severity (..), (<&))
 -- file or GHC session according to the provided 'Cradle'.
 getCompilerOptions
   :: LogAction IO (WithSeverity Log)
-  -> FilePath -- The file we are loading it because of
+  -> FilePath -- ^ The file we are loading it because of
+  -> [FilePath] -- ^ previous files we might want to include in the build
   -> Cradle a
   -> IO (CradleLoadResult ComponentOptions)
-getCompilerOptions l fp cradle = do
+getCompilerOptions l fp fps cradle = do
   l <& LogProcessOutput "invoking build tool to determine build flags (this may take some time depending on the cache)" `WithSeverity` Info
-  runCradle (cradleOptsProg cradle) l fp
+  runCradle (cradleOptsProg cradle) l fp fps

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -7,11 +7,10 @@ import Colog.Core (LogAction (..), WithSeverity (..), Severity (..), (<&))
 -- | Initialize the 'DynFlags' relating to the compilation of a single
 -- file or GHC session according to the provided 'Cradle'.
 getCompilerOptions
-  :: LogAction IO (WithSeverity Log)
-  -> FilePath -- ^ The file we are loading it because of
+  :: FilePath -- ^ The file we are loading it because of
   -> [FilePath] -- ^ previous files we might want to include in the build
   -> Cradle a
   -> IO (CradleLoadResult ComponentOptions)
-getCompilerOptions l fp fps cradle = do
-  l <& LogProcessOutput "invoking build tool to determine build flags (this may take some time depending on the cache)" `WithSeverity` Info
-  runCradle (cradleOptsProg cradle) l fp fps
+getCompilerOptions fp fps cradle = do
+  (cradleLogger cradle) <& LogProcessOutput "invoking build tool to determine build flags (this may take some time depending on the cache)" `WithSeverity` Info
+  runCradle (cradleOptsProg cradle) fp fps

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -33,24 +33,22 @@ import HIE.Bios.Flags
 -- | Initialize a GHC session by loading a given file into a given cradle.
 initializeFlagsWithCradle ::
     GhcMonad m
-    => LogAction IO (WithSeverity Log)
-    -> FilePath -- ^ The file we are loading the 'Cradle' because of
+    => FilePath -- ^ The file we are loading the 'Cradle' because of
     -> Cradle a   -- ^ The cradle we want to load
     -> m (CradleLoadResult (m G.SuccessFlag, ComponentOptions))
-initializeFlagsWithCradle l = initializeFlagsWithCradleWithMessage l (Just Gap.batchMsg)
+initializeFlagsWithCradle = initializeFlagsWithCradleWithMessage (Just Gap.batchMsg)
 
 -- | The same as 'initializeFlagsWithCradle' but with an additional argument to control
 -- how the loading progress messages are displayed to the user. In @haskell-ide-engine@
 -- the module loading progress is displayed in the UI by using a progress notification.
 initializeFlagsWithCradleWithMessage ::
   GhcMonad m
-  => LogAction IO (WithSeverity Log)
-  -> Maybe G.Messager
+  => Maybe G.Messager
   -> FilePath -- ^ The file we are loading the 'Cradle' because of
   -> Cradle a  -- ^ The cradle we want to load
   -> m (CradleLoadResult (m G.SuccessFlag, ComponentOptions)) -- ^ Whether we actually loaded the cradle or not.
-initializeFlagsWithCradleWithMessage l msg fp cradle =
-    fmap (initSessionWithMessage msg) <$> liftIO (getCompilerOptions l fp [] cradle)
+initializeFlagsWithCradleWithMessage msg fp cradle =
+    fmap (initSessionWithMessage msg) <$> liftIO (getCompilerOptions fp [] cradle)
 
 -- | Actually perform the initialisation of the session. Initialising the session corresponds to
 -- parsing the command line flags, setting the targets for the session and then attempting to load

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -50,7 +50,7 @@ initializeFlagsWithCradleWithMessage ::
   -> Cradle a  -- ^ The cradle we want to load
   -> m (CradleLoadResult (m G.SuccessFlag, ComponentOptions)) -- ^ Whether we actually loaded the cradle or not.
 initializeFlagsWithCradleWithMessage l msg fp cradle =
-    fmap (initSessionWithMessage msg) <$> liftIO (getCompilerOptions l fp cradle)
+    fmap (initSessionWithMessage msg) <$> liftIO (getCompilerOptions l fp [] cradle)
 
 -- | Actually perform the initialisation of the session. Initialising the session corresponds to
 -- parsing the command line flags, setting the targets for the session and then attempting to load

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -46,18 +46,17 @@ instance Pretty Log where
 -- | Checking syntax of a target file using GHC.
 --   Warnings and errors are returned.
 checkSyntax :: Show a
-            => LogAction IO (WithSeverity T.Log)
-            -> LogAction IO (WithSeverity Log)
+            => LogAction IO (WithSeverity Log)
             -> Cradle a
             -> [FilePath]  -- ^ The target files.
             -> IO String
-checkSyntax _       _          _      []    = return ""
-checkSyntax logger checkLogger cradle files = do
-    libDirRes <- getRuntimeGhcLibDir logger cradle
+checkSyntax _           _      []    = return ""
+checkSyntax checkLogger cradle files = do
+    libDirRes <- getRuntimeGhcLibDir cradle
     handleRes libDirRes $ \libDir ->
       G.runGhcT (Just libDir) $ do
         liftIO $ checkLogger <& LogCradle cradle `WithSeverity` Info
-        res <- initializeFlagsWithCradle (cmap (fmap LogAny) checkLogger) (head files) cradle
+        res <- initializeFlagsWithCradle (head files) cradle
         handleRes res $ \(ini, _) -> do
           _sf <- ini
           either id id <$> check checkLogger files

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -25,17 +25,17 @@ import System.Directory
 --
 -- Otherwise, shows the error message and exit-code.
 debugInfo :: Show a
-          => LogAction IO (WithSeverity Log)
-          -> FilePath
+          => FilePath
           -> Cradle a
           -> IO String
-debugInfo logger fp cradle = unlines <$> do
-    res <- getCompilerOptions logger fp [] cradle
+debugInfo fp cradle = unlines <$> do
+    let logger = cradleLogger cradle
+    res <- getCompilerOptions fp [] cradle
     canonFp <- canonicalizePath fp
     conf <- findConfig canonFp
-    crdl <- findCradle' canonFp
-    ghcLibDir <- getRuntimeGhcLibDir logger cradle
-    ghcVer <- getRuntimeGhcVersion logger cradle
+    crdl <- findCradle' logger canonFp
+    ghcLibDir <- getRuntimeGhcLibDir cradle
+    ghcVer <- getRuntimeGhcVersion cradle
     case res of
       CradleSuccess (ComponentOptions gopts croot deps) -> do
         return [
@@ -84,19 +84,19 @@ findConfig fp = findCradle fp >>= \case
 
 ----------------------------------------------------------------
 
-cradleInfo :: [FilePath] -> IO String
-cradleInfo [] = return "No files given"
-cradleInfo args =
+cradleInfo :: LogAction IO (WithSeverity Log) -> [FilePath] -> IO String
+cradleInfo _ [] = return "No files given"
+cradleInfo l args =
   fmap unlines $ forM args $ \fp -> do
     fp' <- canonicalizePath fp
-    (("Cradle for \"" ++ fp' ++ "\": ") ++)  <$> findCradle' fp'
+    (("Cradle for \"" ++ fp' ++ "\": ") ++)  <$> findCradle' l fp'
 
-findCradle' :: FilePath -> IO String
-findCradle' fp =
+findCradle' :: LogAction IO (WithSeverity Log) -> FilePath -> IO String
+findCradle' l fp =
   findCradle fp >>= \case
     Just yaml -> do
-      crdl <- loadCradle yaml
+      crdl <- loadCradle l yaml
       return $ show crdl
     Nothing -> do
-      crdl <- loadImplicitCradle fp :: IO (Cradle Void)
+      crdl <- loadImplicitCradle l fp :: IO (Cradle Void)
       return $ show crdl

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -30,7 +30,7 @@ debugInfo :: Show a
           -> Cradle a
           -> IO String
 debugInfo logger fp cradle = unlines <$> do
-    res <- getCompilerOptions logger fp cradle
+    res <- getCompilerOptions logger fp [] cradle
     canonFp <- canonicalizePath fp
     conf <- findConfig canonFp
     crdl <- findCradle' canonFp

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -113,7 +113,7 @@ instance Pretty Log where
 data CradleAction a = CradleAction {
                         actionName    :: ActionName a
                       -- ^ Name of the action.
-                      , runCradle     :: L.LogAction IO (L.WithSeverity Log) -> FilePath -> IO (CradleLoadResult ComponentOptions)
+                      , runCradle     :: L.LogAction IO (L.WithSeverity Log) -> FilePath -> [FilePath] -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
                       , runGhcCmd     :: L.LogAction IO (L.WithSeverity Log) -> [String] -> IO (CradleLoadResult String)
                       -- ^ Executes the @ghc@ binary that is usually used to

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -70,7 +70,14 @@ data Cradle a = Cradle {
   -- | The action which needs to be executed to get the correct
   -- command line arguments.
   , cradleOptsProg   :: CradleAction a
-  } deriving (Show, Functor)
+  , cradleLogger  :: L.LogAction IO (L.WithSeverity Log)
+  } deriving (Functor)
+
+instance Show a => Show (Cradle a) where
+  show (Cradle root prog _)
+    = "Cradle{ cradleRootDir = " ++ show root
+          ++", cradleOptsProg = " ++ show prog
+          ++"}"
 
 data ActionName a
   = Stack
@@ -113,9 +120,9 @@ instance Pretty Log where
 data CradleAction a = CradleAction {
                         actionName    :: ActionName a
                       -- ^ Name of the action.
-                      , runCradle     :: L.LogAction IO (L.WithSeverity Log) -> FilePath -> [FilePath] -> IO (CradleLoadResult ComponentOptions)
+                      , runCradle     :: FilePath -> [FilePath] -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
-                      , runGhcCmd     :: L.LogAction IO (L.WithSeverity Log) -> [String] -> IO (CradleLoadResult String)
+                      , runGhcCmd     :: [String] -> IO (CradleLoadResult String)
                       -- ^ Executes the @ghc@ binary that is usually used to
                       -- build the cradle. E.g. for a cabal cradle this should be
                       -- equivalent to @cabal exec ghc -- args@

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -114,7 +114,7 @@ assertCustomParser fp cc = do
                           , "Expected: " ++ show cc
                           , "Actual: " ++ show conf ])
 
-noDeps :: CradleType a -> Config a
+noDeps :: CradleTree a -> Config a
 noDeps c = Config (CradleConfig [] c)
 
 shouldThrow :: (HasCallStack, Exception e) => IO a -> Selector e -> Assertion

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -253,15 +253,15 @@ initCradle fp = do
   relMcfg <- traverse relFile mcfg
   step $ "Loading Cradle: " <> show relMcfg
   crd <- case mcfg of
-    Just cfg -> liftIO $ loadCradle cfg
-    Nothing -> liftIO $ loadImplicitCradle a_fp
+    Just cfg -> liftIO $ loadCradle testLogger cfg
+    Nothing -> liftIO $ loadImplicitCradle testLogger a_fp
   setCradle crd
 
 initImplicitCradle :: FilePath -> TestM ()
 initImplicitCradle fp = do
   a_fp <- normFile fp
   step $ "Loading implicit Cradle for: " <> fp
-  crd <- liftIO $ loadImplicitCradle a_fp
+  crd <- liftIO $ loadImplicitCradle testLogger a_fp
   setCradle crd
 
 loadComponentOptions :: FilePath -> TestM ()
@@ -269,21 +269,21 @@ loadComponentOptions fp = do
   a_fp <- normFile fp
   crd <- askCradle
   step $ "Initialise flags for: " <> fp
-  clr <- liftIO $ getCompilerOptions mempty a_fp [] crd
+  clr <- liftIO $ getCompilerOptions a_fp [] crd
   setLoadResult clr
 
 loadRuntimeGhcLibDir :: TestM ()
 loadRuntimeGhcLibDir = do
   crd <- askCradle
   step "Load run-time ghc libdir"
-  libdirRes <- liftIO $ getRuntimeGhcLibDir testLogger crd
+  libdirRes <- liftIO $ getRuntimeGhcLibDir crd
   setLibDirResult libdirRes
 
 loadRuntimeGhcVersion :: TestM ()
 loadRuntimeGhcVersion = do
   crd <- askCradle
   step "Load run-time ghc version"
-  ghcVersionRes <- liftIO $ getRuntimeGhcVersion testLogger crd
+  ghcVersionRes <- liftIO $ getRuntimeGhcVersion crd
   setGhcVersionResult ghcVersionRes
 
 testLogger :: forall a . Pretty a => L.LogAction IO (L.WithSeverity a)

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -269,7 +269,7 @@ loadComponentOptions fp = do
   a_fp <- normFile fp
   crd <- askCradle
   step $ "Initialise flags for: " <> fp
-  clr <- liftIO $ getCompilerOptions mempty a_fp crd
+  clr <- liftIO $ getCompilerOptions mempty a_fp [] crd
   setLoadResult clr
 
 loadRuntimeGhcLibDir :: TestM ()
@@ -325,7 +325,7 @@ loadFileGhc fp = do
 assertCradle :: (Cradle Void -> Bool) -> TestM ()
 assertCradle cradlePred = do
   crd <- askCradle
-  liftIO $ cradlePred crd @? "Must be the correct kind of cradle"
+  liftIO $ cradlePred crd @? "Must be the correct kind of cradle, got " ++ show (actionName $ cradleOptsProg crd)
 
 assertLibDirVersion :: TestM ()
 assertLibDirVersion = assertLibDirVersionIs VERSION_ghc


### PR DESCRIPTION
Support for cabal multi-component

new versions of cabal-install (>= 3.11) have support for starting
multi-component repls which allow us to correctly load multiple components,
cruicially including the correct transitive closure of all the components we
need for correct HLS support.

This works by passing multiple targets to `cabal repl`, i.e.
`cabal repl target1 target2 ...`

In order to do this, we must know all the previous targets we have loaded,
so `runCradle` gets an extra `[FilePath]` argument so that this can be supplied.

This is the only externally visible API change in this patch.

`hie-bios` sometimes passes raw `FilePath`s as targets, and sometimes
actual component names (lib:foo, test:foo, exe:bar ...)

The latter happes when we have user configuration in the hie.yaml explicitly
specifying component names.

As downstream users of hie-bios have no concept of "component names", they
only know about files which caused a particular component to be loaded, we
must handle mapping back from `FilePath`s when starting a multi-component session.

It was not easy to do this with the way the code previously work with multi-cradles
and `getCradle` and `multiAction` being mutually recursive.

So now we uniformly treat everything as a multi-cradle of sorts, resolving the
configuration tree from hie.yaml (which I took care not to change) into a
list of `ResolvedCradle`s ordered by prefixes, which can easily be consulted
by the cabal multi-component cradle to map `FilePath`s back to component
names when needed.
