### PR TITLE
improve implicit cradle

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -172,6 +172,7 @@ Library
                         exceptions           ^>= 0.10,
                         cryptohash-sha1      >= 0.11.100 && < 0.12,
                         directory            >= 1.3.0 && < 1.4,
+                        implicit-hie         >= 0.1.4.0 && < 0.1.5,
                         filepath             >= 1.4.1 && < 1.5,
                         time                 >= 1.8.0 && < 1.13,
                         extra                >= 1.6.14 && < 1.8,


### PR DESCRIPTION
Improve implicit cradles.

Try to match the behaviour of implicit-hie-cradle as closely as possible.

Elminates the need for implicit-hie-cradle and consolidates cradle selection
logic into hie-bios.

1. Prefer cabal over stack (all else being equal)
2. Take work directories into account when making a decision
3. Use `implicit-hie` to generate stack multi cradles

In particular, this differs from `implicit-hie-cradle` in that it uses default
(`cradle: cabal:`) cradles for cabal.

However, we still generate implicit multi-cradles for stack projects by parsing
the stack.yaml and *.cabal files
