### PR TITLE
Update GHC versions in CI, drop ghcs not supported by hls (resolves #410)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,18 +15,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.8.1', '9.6.3', '9.4.7', '9.2.8', '9.0.2', '8.10.7']
+        ghc: ['9.8.2', '9.6.4', '9.4.8', '9.2.8']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
     - id:   extra-ghc
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         cabal-version: '3.10.2.0'
         ghc-version: '8.10.7'
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.10.2.0'
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
     - name: Check
       run: cabal check
     - name: Generate sdist
@@ -80,13 +80,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ludeeus/action-shellcheck@master
       with:
-        ignore: tests
+        ignore_paths: tests
 
   windows-wrapper:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
     - name: Compile Windows wrapper

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -139,7 +139,7 @@ Extra-Source-Files:     ChangeLog.md
                         tests/projects/stack-with-yaml/stack-with-yaml.cabal
                         tests/projects/stack-with-yaml/src/Lib.hs
 
-tested-with: GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.6 || ==9.6.2 || ==9.8.1
+tested-with: GHC ==9.2.8 || ==9.4.8 || ==9.6.4 || ==9.8.2
 
 Library
   Default-Language:     Haskell2010

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -350,18 +350,14 @@ stackYaml resolver pkgs = unlines
 
 stackYamlResolver :: String
 stackYamlResolver =
-#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,6,2,0)))
-  "nightly-2023-11-13" -- GHC 9.6.3
-#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,4,4,0)))
-  "lts-21.20" -- GHC 9.4.7
-#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,2,7,0)))
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,8,0,0)))
+  "nightly-2024-02-26" -- GHC 9.8.1
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,6,0,0)))
+  "lts-22.12" -- GHC 9.6.4
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)))
+  "lts-21.25" -- GHC 9.4.8
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)))
   "lts-20.26" -- GHC 9.2.8
-#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,2,1,0)))
-  "lts-20.11" -- GHC 9.2.5
-#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(9,0,1,0)))
-  "lts-19.33" -- GHC 9.0.2
-#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,10,7,0)))
-  "lts-18.28" -- GHC 8.10.7
 #endif
 
 -- ------------------------------------------------------------------


### PR DESCRIPTION
Resolves https://github.com/haskell/hie-bios/issues/410
and also drops ghc 9.0 from CI which at this point is also not supported by hls.

When dropping older versions of ghc from CI, would it make sense to also bump the ghc bounds in cabal file?

There is bunch of CPP code related to older ghc versions.
I'd like to clean that up in followup PR.