### PR TITLE
Cleanup CPP for GHCs < 9.2, fix most GHC warnings

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -6,7 +6,7 @@ module Main where
 import Control.Monad ( forM )
 import qualified Colog.Core as L
 import Data.Version (showVersion)
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Options.Applicative
 import System.Directory (getCurrentDirectory)
 import System.IO (stdout, hSetEncoding, utf8)

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -176,7 +176,7 @@ Library
                         time                 >= 1.8.0 && < 1.13,
                         extra                >= 1.6.14 && < 1.8,
                         prettyprinter        ^>= 1.6 || ^>= 1.7.0,
-                        ghc                  >= 8.10.1 && < 9.9,
+                        ghc                  >= 9.2.1 && < 9.9,
                         transformers         >= 0.5.2 && < 0.7,
                         temporary            >= 1.2 && < 1.4,
                         template-haskell,

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -12,8 +12,8 @@ Description:            Set up a GHC API session and obtain flags required to co
 Category:               Development
 Build-Type:             Simple
 -- No glob syntax until GHC 8.6 because of stack
-Extra-Source-Files:     ChangeLog.md
-                        README.md
+extra-doc-files:        ChangeLog.md
+Extra-Source-Files:     README.md
                         wrappers/cabal
                         wrappers/cabal.hs
                         tests/configs/*.yaml
@@ -163,7 +163,7 @@ Library
   Other-Modules:        Paths_hie_bios
   autogen-modules:      Paths_hie_bios
   Build-Depends:
-                        base                 >= 4.14 && < 5,
+                        base                 >= 4.16 && < 5,
                         aeson                >= 1.4.4 && < 2.3,
                         base16-bytestring    >= 0.1.1 && < 1.1,
                         bytestring           >= 0.10.8 && < 0.13,
@@ -195,7 +195,7 @@ Executable hie-bios
   Other-Modules:        Paths_hie_bios
   GHC-Options:          -Wall
   HS-Source-Dirs:       exe
-  Build-Depends:        base >= 4.9 && < 5
+  Build-Depends:        base >= 4.16 && < 5
                       , co-log-core
                       , directory
                       , filepath

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -25,7 +25,6 @@ module HIE.Bios.Cradle (
     , makeCradleResult
     -- | Cradle project configuration types
     , CradleProjectConfig(..)
-    ,
   ) where
 
 import Control.Applicative ((<|>), optional)

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -805,8 +805,8 @@ cabalAction (ResolvedCradles root cs vs) workDir mc l projectFile fp fps = do
           -- Start a multi-component session with all the old files
           _ -> "--keep-temp-files"
              : "--enable-multi-repl"
-             : [fromMaybe (fixTargetPath fp) mc]
-            ++ [fromMaybe (fixTargetPath old_fp) old_mc
+             : fromMaybe (fixTargetPath fp) mc
+             : [fromMaybe (fixTargetPath old_fp) old_mc
                | old_fp <- fps
                -- Lookup the component for the old file
                , Just (ResolvedCradle{concreteCradle = ConcreteCabal ct}) <- [selectCradle prefix old_fp cs]

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -150,7 +150,7 @@ addCmdOpts cmdOpts df1 = do
   let leftovers = map G.unLoc leftovers' ++ additionalTargets
 
   let (df3, srcs, _objs) = Gap.parseTargetFiles df2 leftovers
-  ts <- mapM (uncurry (\f phase -> Gap.guessTarget f (Just $ Gap.homeUnitId_ df3) phase) ) srcs
+  ts <- mapM (\(f, phase) -> Gap.guessTarget f (Just $ Gap.homeUnitId_ df3) phase) srcs
   return (df3, ts)
 
 -- | Make filepaths in the given 'DynFlags' absolute.

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -11,15 +11,7 @@ module HIE.Bios.Ghc.Api (
 
 import GHC (LoadHowMuch(..), DynFlags, GhcMonad)
 import qualified GHC as G
-
-#if __GLASGOW_HASKELL__ >= 900
 import qualified GHC.Driver.Main as G
-import qualified GHC.Driver.Make as G
-#else
-import qualified HscMain as G
-import qualified GhcMake as G
-#endif
-
 import qualified HIE.Bios.Ghc.Gap as Gap
 import Control.Monad (void)
 import Control.Monad.IO.Class

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -14,7 +14,7 @@ import qualified GHC as G
 import Control.Exception
 import Control.Monad.IO.Class
 import Colog.Core (LogAction (..), WithSeverity (..), Severity (..), (<&), cmap)
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Ghc.Logger

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -44,12 +44,12 @@ checkSyntax :: Show a
             -> [FilePath]  -- ^ The target files.
             -> IO String
 checkSyntax _           _      []    = return ""
-checkSyntax checkLogger cradle files = do
+checkSyntax checkLogger cradle files@(file:_) = do
     libDirRes <- getRuntimeGhcLibDir cradle
     handleRes libDirRes $ \libDir ->
       G.runGhcT (Just libDir) $ do
         liftIO $ checkLogger <& LogCradle cradle `WithSeverity` Info
-        res <- initializeFlagsWithCradle (head files) cradle
+        res <- initializeFlagsWithCradle file cradle
         handleRes res $ \(ini, _) -> do
           _sf <- ini
           either id id <$> check checkLogger files

--- a/src/HIE/Bios/Ghc/Doc.hs
+++ b/src/HIE/Bios/Ghc/Doc.hs
@@ -12,16 +12,14 @@ import GHC (DynFlags
 import GHC.Utils.Outputable
 #endif
 
-#if __GLASGOW_HASKELL__ >= 900
 import GHC.Driver.Session (initSDocContext)
-import GHC.Utils.Outputable (PprStyle, SDoc, runSDoc, neverQualify, )
 import GHC.Utils.Ppr  (Mode(..), Doc, Style(..), renderStyle, style)
-#else
-import Outputable (PprStyle, SDoc, runSDoc, neverQualify, initSDocContext)
-import Pretty (Mode(..), Doc, Style(..), renderStyle, style)
-#endif
 
 import HIE.Bios.Ghc.Gap (makeUserStyle, pageMode, oneLineMode)
+
+#if __GLASGOW_HASKELL__ < 905
+import GHC.Utils.Outputable (PprStyle, SDoc, runSDoc, neverQualify, )
+#endif
 
 #if __GLASGOW_HASKELL__ >= 905
 getPrintUnqual :: Monad m => m NamePprCtx

--- a/src/HIE/Bios/Ghc/Gap.hs
+++ b/src/HIE/Bios/Ghc/Gap.hs
@@ -60,35 +60,9 @@ import qualified Control.Monad.Catch as E
 import GHC
 import qualified GHC as G
 
-#if __GLASGOW_HASKELL__ >= 810 && __GLASGOW_HASKELL__ < 900
-import Data.List
-import System.FilePath
-
-import DynFlags (LogAction, WarningFlag, updOptLevel, Way(WayDyn), updateWays, addWay', getDynFlags)
-import qualified DynFlags as G
-import qualified Exception as G
-
-import Outputable (PprStyle, Depth(AllTheWay), mkUserStyle)
-import HscMain (getHscEnv, batchMsg)
-import HscTypes (Hsc, HscEnv(..))
-import qualified HscTypes as G
-import qualified EnumSet as E (EnumSet, empty)
-import qualified Pretty as Ppr
-import qualified TcRnTypes as Tc
-import Hooks (Hooks(hscFrontendHook))
-import qualified CmdLineParser as CmdLine
-import DriverPhases as G
-import Util as G
-import qualified GhcMonad as G
-
-import qualified DynamicLoading (initializePlugins)
-import qualified Plugins (plugins)
-#endif
 ----------------------------------------------------------------
 ----------------------------------------------------------------
 
-#if __GLASGOW_HASKELL__ >= 902
-import GHC.Driver.CmdLine as CmdLine
 import GHC.Driver.Env as G
 import GHC.Driver.Session as G
 import GHC.Driver.Hooks
@@ -99,60 +73,27 @@ import GHC.Platform.Ways (Way(WayDyn))
 import qualified GHC.Platform.Ways as Platform
 import qualified GHC.Runtime.Loader as DynamicLoading (initializePlugins)
 import qualified GHC.Tc.Types as Tc
-
 import GHC.Utils.Logger
 import GHC.Utils.Outputable
 import qualified GHC.Utils.Ppr as Ppr
-#elif __GLASGOW_HASKELL__ >= 900
-import Data.List
-import System.FilePath
+import qualified GHC.Driver.Make as G
 
-import GHC.Core.Multiplicity (irrelevantMult)
-import GHC.Data.EnumSet as E
-import GHC.Driver.CmdLine as CmdLine
-import GHC.Driver.Types as G
-import GHC.Driver.Session as G
-import GHC.Driver.Hooks
-import GHC.Driver.Main
-import GHC.Driver.Monad as G
-import GHC.Driver.Phases as G
-import GHC.Utils.Misc as G
-import qualified GHC.Driver.Plugins as Plugins
-import GHC.Driver.Ways (Way(WayDyn))
-import qualified GHC.Driver.Ways as Platform
-import qualified GHC.Runtime.Loader as DynamicLoading (initializePlugins)
-import qualified GHC.Tc.Types as Tc
-
-import GHC.Utils.Outputable
-import qualified GHC.Utils.Ppr as Ppr
-#endif
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ > 903
 import GHC.Unit.Types (UnitId)
 #endif
-
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ < 904
 import qualified GHC.Driver.Main as G
-import qualified GHC.Driver.Make as G
-#else
-import qualified HscMain as G
-import qualified GhcMake as G
 #endif
-
 #if __GLASGOW_HASKELL__ >= 907
 import GHC.Types.Error (mkUnknownDiagnostic, Messages)
 import GHC.Driver.Errors.Types (DriverMessage)
 #endif
+#if __GLASGOW_HASKELL__ < 907
+import GHC.Driver.CmdLine as CmdLine
+#endif
 
 ghcVersion :: String
 ghcVersion = VERSION_ghc
-
-#if __GLASGOW_HASKELL__ <= 810
-homeUnitId_ :: a -> ()
-homeUnitId_ = const ()
-#elif __GLASGOW_HASKELL__ <= 901
-homeUnitId_ :: DynFlags -> UnitId
-homeUnitId_ = homeUnitId
-#endif
 
 #if __GLASGOW_HASKELL__ >= 907
 load' :: GhcMonad m => Maybe G.ModIfaceCache -> LoadHowMuch -> Maybe Messager -> ModuleGraph -> m SuccessFlag
@@ -165,23 +106,12 @@ load' :: GhcMonad m => a -> LoadHowMuch -> Maybe G.Messager -> ModuleGraph -> m 
 load' _ a b c = G.load' a b c
 #endif
 
-#if __GLASGOW_HASKELL__ >= 900
 bracket :: E.MonadMask m => m a -> (a -> m c) -> (a -> m b) -> m b
 bracket =
   E.bracket
-#else
-bracket :: G.ExceptionMonad m => m a -> (a -> m c) -> (a -> m b) -> m b
-bracket =
-  G.gbracket
-#endif
 
-#if __GLASGOW_HASKELL__ >= 900
 handle :: (E.MonadCatch m, E.Exception e) => (e -> m a) -> m a -> m a
 handle = E.handle
-#else
-handle :: (G.ExceptionMonad m, E.Exception e) => (e -> m a) -> m a -> m a
-handle = G.ghandle
-#endif
 
 catch :: (E.MonadCatch m, E.Exception e) => m a -> (e -> m a) -> m a
 catch =
@@ -190,21 +120,15 @@ catch =
 ----------------------------------------------------------------
 
 pattern RealSrcSpan :: G.RealSrcSpan -> G.SrcSpan
-#if __GLASGOW_HASKELL__ >= 900
 pattern RealSrcSpan t <- G.RealSrcSpan t _
-#else
-pattern RealSrcSpan t <- G.RealSrcSpan t
-#endif
 
 ----------------------------------------------------------------
 
 setNoCode :: DynFlags -> DynFlags
 #if __GLASGOW_HASKELL__ >= 905
 setNoCode d = d { G.backend = G.noBackend }
-#elif __GLASGOW_HASKELL__ >= 901
-setNoCode d = d { G.backend = G.NoBackend }
 #else
-setNoCode d = d { G.hscTarget = G.HscNothing }
+setNoCode d = d { G.backend = G.NoBackend }
 #endif
 
 ----------------------------------------------------------------
@@ -213,14 +137,9 @@ set_hsc_dflags :: DynFlags -> HscEnv -> HscEnv
 set_hsc_dflags dflags hsc_env = hsc_env { G.hsc_dflags = dflags }
 
 overPkgDbRef :: (FilePath -> FilePath) -> G.PackageDBFlag -> G.PackageDBFlag
-overPkgDbRef f (G.PackageDB pkgConfRef) = G.PackageDB
-              $ case pkgConfRef of
-#if __GLASGOW_HASKELL__ >= 900
-                G.PkgDbPath fp -> G.PkgDbPath (f fp)
-#else
-                G.PkgConfFile fp -> G.PkgConfFile (f fp)
-#endif
-                conf -> conf
+overPkgDbRef f (G.PackageDB pkgConfRef) = G.PackageDB $ case pkgConfRef of
+    G.PkgDbPath fp -> G.PkgDbPath (f fp)
+    conf -> conf
 overPkgDbRef _f db = db
 
 ----------------------------------------------------------------
@@ -240,14 +159,10 @@ makeUserStyle :: DynFlags -> NamePprCtx -> PprStyle
 #else
 makeUserStyle :: DynFlags -> PrintUnqualified -> PprStyle
 #endif
-#if __GLASGOW_HASKELL__ >= 900
 makeUserStyle _dflags style = mkUserStyle style AllTheWay
-#elif __GLASGOW_HASKELL__ >= 804
-makeUserStyle dflags style = mkUserStyle dflags style AllTheWay
-#endif
 
 ----------------------------------------------------------------
-#if __GLASGOW_HASKELL__ >= 810
+
 getModSummaries :: ModuleGraph -> [ModSummary]
 getModSummaries = mgModSummaries
 
@@ -256,20 +171,17 @@ getTyThing (t,_,_,_,_) = t
 
 fixInfo :: (a, b, c, d, e) -> (a, b, c, d)
 fixInfo (t,f,cs,fs,_) = (t,f,cs,fs)
-#endif
 
 ----------------------------------------------------------------
 
 mapOverIncludePaths :: (FilePath -> FilePath) -> DynFlags -> DynFlags
 mapOverIncludePaths f df = df
   { includePaths =
-#if __GLASGOW_HASKELL__ >= 810
       G.IncludeSpecs
           (map f $ G.includePathsQuote  (includePaths df))
           (map f $ G.includePathsGlobal (includePaths df))
 #if MIN_VERSION_GLASGOW_HASKELL(9,0,2,0)
           (map f $ G.includePathsQuoteImplicit (includePaths df))
-#endif
 #endif
   }
 
@@ -277,25 +189,16 @@ mapOverIncludePaths f df = df
 
 unsetLogAction :: GhcMonad m => m ()
 unsetLogAction = do
-#if __GLASGOW_HASKELL__ >= 902
     hsc_env <- getSession
     logger <- liftIO $ initLogger
     let env = hsc_env { hsc_logger = pushLogHook (const noopLogger) logger }
     setSession env
-#else
-    setLogAction noopLogger
-#if __GLASGOW_HASKELL__ < 806
-        (\_df -> return ())
-#endif
-#endif
 
 noopLogger :: LogAction
 #if __GLASGOW_HASKELL__ >= 903
 noopLogger = (\_wr _s _ss _m -> return ())
-#elif __GLASGOW_HASKELL__ >= 900
-noopLogger = (\_df _wr _s _ss _m -> return ())
 #else
-noopLogger = (\_df _wr _s _ss _pp _m -> return ())
+noopLogger = (\_df _wr _s _ss _m -> return ())
 #endif
 
 -- --------------------------------------------------------
@@ -304,11 +207,7 @@ noopLogger = (\_df _wr _s _ss _pp _m -> return ())
 
 pageMode :: Ppr.Mode
 pageMode =
-#if __GLASGOW_HASKELL__ >= 902
   Ppr.PageMode True
-#else
-  Ppr.PageMode
-#endif
 
 oneLineMode :: Ppr.Mode
 oneLineMode = Ppr.OneLineMode
@@ -320,39 +219,20 @@ oneLineMode = Ppr.OneLineMode
 numLoadedPlugins :: HscEnv -> Int
 #if __GLASGOW_HASKELL__ >= 903
 numLoadedPlugins = length . Plugins.pluginsWithArgs . hsc_plugins
-#elif __GLASGOW_HASKELL__ >= 902
-numLoadedPlugins = length . Plugins.plugins
-#elif __GLASGOW_HASKELL__ >= 808
-numLoadedPlugins = length . Plugins.plugins . hsc_dflags
 #else
--- Plugins are loaded just as they are used
-numLoadedPlugins _ = 0
+numLoadedPlugins = length . Plugins.plugins
 #endif
 
 initializePluginsForModSummary :: HscEnv -> ModSummary -> IO (Int, [G.ModuleName], ModSummary)
 initializePluginsForModSummary hsc_env' mod_summary = do
-#if __GLASGOW_HASKELL__ >= 902
   hsc_env <- DynamicLoading.initializePlugins hsc_env'
   pure ( numLoadedPlugins hsc_env
        , pluginModNames $ hsc_dflags hsc_env
        , mod_summary
        )
-#elif __GLASGOW_HASKELL__ >= 808
-  let dynFlags' = G.ms_hspp_opts mod_summary
-  dynFlags <- DynamicLoading.initializePlugins hsc_env' dynFlags'
-  pure ( numLoadedPlugins $ set_hsc_dflags dynFlags hsc_env'
-       , G.pluginModNames dynFlags
-       , mod_summary { G.ms_hspp_opts = dynFlags }
-       )
-#else
-  -- In earlier versions of GHC plugins are just loaded before they are used.
-  return (numLoadedPlugins hsc_env', G.pluginModNames $ hsc_dflags hsc_env', mod_summary)
-#endif
-
 
 setFrontEndHooks :: Maybe (ModSummary -> G.Hsc Tc.FrontendResult) -> HscEnv -> HscEnv
 setFrontEndHooks frontendHook env =
-#if __GLASGOW_HASKELL__ >= 902
   env
     { hsc_hooks = hooks
         { hscFrontendHook = frontendHook
@@ -360,30 +240,10 @@ setFrontEndHooks frontendHook env =
     }
   where
     hooks = hsc_hooks env
-#else
-  env
-    { G.hsc_dflags = flags
-        { G.hooks = oldhooks
-            { hscFrontendHook = frontendHook
-            }
-        }
-    }
-  where
-    flags = hsc_dflags env
-    oldhooks = G.hooks flags
-#endif
-
-#if __GLASGOW_HASKELL__ < 902
-type Logger = ()
-#endif
 
 getLogger :: HscEnv -> Logger
 getLogger =
-#if __GLASGOW_HASKELL__ >= 902
     hsc_logger
-#else
-    const ()
-#endif
 
 gopt_set :: DynFlags -> G.GeneralFlag -> DynFlags
 gopt_set = G.gopt_set
@@ -396,11 +256,9 @@ setWayDynamicIfHostIsDynamic =
     else
       id
 
-#if __GLASGOW_HASKELL__ >= 900
 updateWays :: DynFlags -> DynFlags
 updateWays = id
 
-#if __GLASGOW_HASKELL__ >= 902
 -- Copied from GHC, do we need that?
 addWay' :: Way -> DynFlags -> DynFlags
 addWay' w dflags0 =
@@ -411,8 +269,6 @@ addWay' w dflags0 =
        dflags3 = foldr unSetGeneralFlag' dflags2
                        (Platform.wayUnsetGeneralFlags platform w)
    in dflags3
-#endif
-#endif
 
 parseDynamicFlags :: MonadIO m
     => Logger
@@ -424,94 +280,15 @@ parseDynamicFlags :: MonadIO m
 #else
           , [CmdLine.Warn])
 #endif
-#if __GLASGOW_HASKELL__ >= 902
 parseDynamicFlags = G.parseDynamicFlags
-#else
-parseDynamicFlags _ = G.parseDynamicFlags
-#endif
+
 
 parseTargetFiles :: DynFlags -> [String] -> (DynFlags, [(String, Maybe G.Phase)], [String])
-#if __GLASGOW_HASKELL__ >= 902
 parseTargetFiles = G.parseTargetFiles
-#else
-parseTargetFiles dflags0 fileish_args =
-  let
-     -- To simplify the handling of filepaths, we normalise all filepaths right
-     -- away. Note the asymmetry of FilePath.normalise:
-     --    Linux:   p/q -> p/q; p\q -> p\q
-     --    Windows: p/q -> p\q; p\q -> p\q
-     -- #12674: Filenames starting with a hypen get normalised from ./-foo.hs
-     -- to -foo.hs. We have to re-prepend the current directory.
-    normalise_hyp fp
-        | strt_dot_sl && "-" `isPrefixOf` nfp = cur_dir ++ nfp
-        | otherwise                           = nfp
-        where
-#if defined(mingw32_HOST_OS)
-          strt_dot_sl = "./" `isPrefixOf` fp || ".\\" `isPrefixOf` fp
-#else
-          strt_dot_sl = "./" `isPrefixOf` fp
-#endif
-          cur_dir = '.' : [pathSeparator]
-          nfp = normalise fp
-    normal_fileish_paths = map normalise_hyp fileish_args
-
-    (srcs, objs) = partition_args normal_fileish_paths [] []
-    df1 = dflags0 { G.ldInputs = map (G.FileOption "") objs ++ G.ldInputs dflags0 }
-  in
-    (df1, srcs, objs)
-#endif
-
-
-#if __GLASGOW_HASKELL__ < 902
-partition_args :: [String] -> [(String, Maybe G.Phase)] -> [String]
-               -> ([(String, Maybe G.Phase)], [String])
--- partition_args, along with some of the other code in this file,
--- was copied from ghc/Main.hs
--- -----------------------------------------------------------------------------
--- Splitting arguments into source files and object files.  This is where we
--- interpret the -x <suffix> option, and attach a (Maybe Phase) to each source
--- file indicating the phase specified by the -x option in force, if any.
-partition_args [] srcs objs = (reverse srcs, reverse objs)
-partition_args ("-x":suff:args) srcs objs
-  | "none" <- suff      = partition_args args srcs objs
-  | G.StopLn <- phase     = partition_args args srcs (slurp ++ objs)
-  | otherwise           = partition_args rest (these_srcs ++ srcs) objs
-        where phase = G.startPhase suff
-              (slurp,rest) = break (== "-x") args
-              these_srcs = zip slurp (repeat (Just phase))
-partition_args (arg:args) srcs objs
-  | looks_like_an_input arg = partition_args args ((arg,Nothing):srcs) objs
-  | otherwise               = partition_args args srcs (arg:objs)
-
-    {-
-      We split out the object files (.o, .dll) and add them
-      to ldInputs for use by the linker.
-      The following things should be considered compilation manager inputs:
-       - haskell source files (strings ending in .hs, .lhs or other
-         haskellish extension),
-       - module names (not forgetting hierarchical module names),
-       - things beginning with '-' are flags that were not recognised by
-         the flag parser, and we want them to generate errors later in
-         checkOptions, so we class them as source files (#5921)
-       - and finally we consider everything without an extension to be
-         a comp manager input, as shorthand for a .hs or .lhs filename.
-      Everything else is considered to be a linker object, and passed
-      straight through to the linker.
-    -}
-looks_like_an_input :: String -> Bool
-looks_like_an_input m =  G.isSourceFilename m
-                      || G.looksLikeModuleName m
-                      || "-" `isPrefixOf` m
-                      || not (hasExtension m)
-#endif
 
 -- --------------------------------------------------------
 -- Platform constants
 -- --------------------------------------------------------
 
 hostIsDynamic :: Bool
-#if __GLASGOW_HASKELL__ >= 900
 hostIsDynamic = Platform.hostIsDynamic
-#else
-hostIsDynamic = G.dynamicGhc
-#endif

--- a/src/HIE/Bios/Ghc/Load.hs
+++ b/src/HIE/Bios/Ghc/Load.hs
@@ -10,23 +10,22 @@ import Control.Monad (forM, void)
 import Control.Monad.IO.Class
 
 import Data.List
-import Data.Time.Clock
+
 import Data.Text.Prettyprint.Doc
 import Data.IORef
 
 import GHC
 import qualified GHC as G
 
-#if __GLASGOW_HASKELL__ >= 900
 import qualified GHC.Driver.Main as G
-import qualified GHC.Driver.Make as G
-#else
-import qualified GhcMake as G
-import qualified HscMain as G
-#endif
 
 import qualified HIE.Bios.Ghc.Gap as Gap
+#if __GLASGOW_HASKELL__ > 903
 import GHC.Fingerprint
+#endif
+#if __GLASGOW_HASKELL__ < 903
+import Data.Time.Clock
+#endif
 
 data Log =
   LogLoaded FilePath FilePath
@@ -119,7 +118,9 @@ msTargetIs ms t = case targetId t of
 -- fool the recompilation checker so that we can get the typechecked modules
 updateTime :: MonadIO m => [Target] -> ModuleGraph -> m ModuleGraph
 updateTime ts graph = liftIO $ do
+#if __GLASGOW_HASKELL__ < 903
   cur_time <- getCurrentTime
+#endif
   let go ms
         | any (msTargetIs ms) ts =
 #if __GLASGOW_HASKELL__ >= 903

--- a/src/HIE/Bios/Ghc/Load.hs
+++ b/src/HIE/Bios/Ghc/Load.hs
@@ -11,7 +11,7 @@ import Control.Monad.IO.Class
 
 import Data.List
 
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Data.IORef
 
 import GHC

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -90,7 +90,7 @@ data ActionName a
   | Other a
   deriving (Show, Eq, Ord, Functor)
 
-data Log 
+data Log
   = LogAny String
   | LogProcessOutput String
   | LogCreateProcessRun CreateProcess
@@ -101,8 +101,8 @@ instance Pretty Log where
   pretty (LogAny s) = pretty s
   pretty (LogProcessOutput s) = pretty s
   pretty (LogProcessRun fp args) = pretty fp <+> pretty (unwords args)
-  pretty (LogCreateProcessRun cp) =   
-    vcat $ 
+  pretty (LogCreateProcessRun cp) =
+    vcat $
       [ case cmdspec cp of
           ShellCommand sh -> pretty sh
           RawCommand cmd args -> pretty cmd <+> pretty (unwords args)
@@ -183,7 +183,7 @@ instance (Monad m, Applicative m) => Applicative (CradleLoadResultT m) where
 
 instance Monad m => Monad (CradleLoadResultT m) where
   {-# INLINE return #-}
-  return = CradleLoadResultT . return . CradleSuccess
+  return = pure
   {-# INLINE (>>=) #-}
   x >>= f = CradleLoadResultT $ do
     val <- runCradleResultT x

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -13,7 +13,7 @@ import           Control.Monad.Trans.Class
 #if MIN_VERSION_base(4,9,0)
 import qualified Control.Monad.Fail as Fail
 #endif
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import System.Process.Extra (CreateProcess (env, cmdspec), CmdSpec (..))
 import Data.Maybe (fromMaybe)
 


### PR DESCRIPTION
Also fixes most ghc warnings.

Contains all the fixes for now out-of-date PR https://github.com/haskell/hie-bios/pull/382 which can be closed if this is merged.
