### PR TITLE
Only pass --keep-temp-files once

### DIFF
--- a/src/HIE/Bios/Cradle/Cabal.hs
+++ b/src/HIE/Bios/Cradle/Cabal.hs
@@ -263,7 +263,7 @@ processCabalLoadStyle l cradles projectFile workDir mc fp loadStyle = do
               allModules = nubOrd $ fst3 <$> allModulesFpsDeps
               allFiles = nubOrd $ snd3 <$> allModulesFpsDeps
               allFpsDeps = nubOrd $ concatMap thd3 allModulesFpsDeps
-           in (["--keep-temp-files", "--enable-multi-repl"] ++ allModules, allFiles, allFpsDeps)
+           in (["--enable-multi-repl"] ++ allModules, allFiles, allFpsDeps)
 
   liftIO $ l <& LogComputedCradleLoadStyle "cabal" loadStyle `WithSeverity` Info
   liftIO $ l <& LogCabalLoad fp mc (prefix <$> resolvedCradles cradles) loadingFiles `WithSeverity` Debug


### PR DESCRIPTION
We already pass this option in `cabalLoadFilesWithRepl`.

Passing it twice results in:

```
Failed to run cabal v2-repl --keep-temp-files --with-repl /home/matt/.cache/hie-bios/repl-wrapper-fae20739a232ed1b9dcdf40eca9cf71e --keep-temp-files --enable-multi-repl all in directory "/home/matt/cabal-sam". Consult the logs for full command and error.
Failed command: cabal '--builddir=/home/matt/.cache/hie-bios/dist-cabal-sam-5794e2e31873c59ce3b213b64b6cfcef' v2-repl --with-compiler /home/matt/.cache/hie-bios/wrapper-b54f81dea4c0e6d1626911c526bc4e36 --with-hc-pkg /home/matt/.cache/hie-bios/ghc-pkg-888afd10bf11a2f2c98c7c83b30ac1de --keep-temp-files --enable-multi-repl all
Build profile: -w ghc-9.10.1 -O1
In order, the following will be built (use -v for more details):
 - Cabal-syntax-3.17.0.0 (interactive) (lib) (first run)
 - cabal-validate-1.0.0 (interactive) (exe:cabal-validate) (first run)
 - solver-benchmarks-3 (interactive) (lib) (dependency rebuilt)
 - hackage-security-0.6.3.2 (interactive) (lib) (dependency rebuilt)
 - Cabal-3.17.0.0 (interactive) (lib) (dependency rebuilt)
 - solver-benchmarks-3 (interactive) (exe:hackage-benchmark) (dependency rebuilt)
 - cabal-install-solver-3.17.0.0 (interactive) (lib) (dependency rebuilt)
 - Cabal-tree-diff-3.17.0.0 (interactive) (lib) (dependency rebuilt)
 - Cabal-tests-3 (interactive) (lib) (dependency rebuilt)
 - Cabal-hooks-3.17 (interactive) (lib) (dependency rebuilt)
 - Cabal-described-3.17.0.0 (interactive) (lib) (dependency rebuilt)
 - Cabal-QuickCheck-3.17.0.0 (interactive) (lib) (dependency rebuilt)
 - cabal-install-3.17.0.0 (interactive) (lib) (dependency rebuilt)
 - cabal-testsuite-3 (interactive) (dependency rebuilt)
 - buildinfo-reference-generator-0 (interactive) (exe:buildinfo-reference-generator) (dependency rebuilt)
 - cabal-install-3.17.0.0 (interactive) (exe:cabal) (dependency rebuilt)
Preprocessing executable 'cabal-validate' for cabal-validate-1.0.0...
Preprocessing library for Cabal-syntax-3.17.0.0...
Preprocessing library for Cabal-3.17.0.0...
Preprocessing library for hackage-security-0.6.3.2...
Preprocessing library for solver-benchmarks-3...
Preprocessing executable 'hackage-benchmark' for solver-benchmarks-3...
Preprocessing library for Cabal-hooks-3.17...
Preprocessing library for Cabal-tests-3...
Preprocessing library for Cabal-QuickCheck-3.17.0.0...
Preprocessing library for cabal-install-solver-3.17.0.0...
Preprocessing library for Cabal-described-3.17.0.0...
Preprocessing library for Cabal-tree-diff-3.17.0.0...
Preprocessing executable 'buildinfo-reference-generator' for buildinfo-reference-generator-0...
Preprocessing library for cabal-install-3.17.0.0...
Preprocessing executable 'cabal' for cabal-install-3.17.0.0...
unrecognized 'repl' option `--keep-temp-files'

Error: [Cabal-7125]
repl failed for cabal-testsuite-3.



Process Environment:
HIE_BIOS_GHC: /nix/store/2b5jf6vy42z8jinw0n023fld1b9xf5xm-ghc-9.10.1/bin/ghc
HIE_BIOS_GHC_ARGS: -B/nix/store/2b5jf6vy42z8jinw0n023fld1b9xf5xm-ghc-9.10.1/lib/ghc-9.10.1/lib
```