### PR TITLE
Improve hie-bios cli interface

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -8,7 +8,7 @@ import qualified Colog.Core as L
 import Data.Version (showVersion)
 import Prettyprinter
 import Options.Applicative
-import System.Directory (getCurrentDirectory)
+import System.Directory (getCurrentDirectory, makeAbsolute)
 import System.IO (stdout, hSetEncoding, utf8)
 import System.FilePath( (</>) )
 
@@ -16,46 +16,69 @@ import HIE.Bios
 import HIE.Bios.Ghc.Check
 import HIE.Bios.Ghc.Gap as Gap
 import HIE.Bios.Internal.Debug
-import HIE.Bios.Types (LoadStyle(LoadFile))
+import HIE.Bios.Types (LoadStyle(..))
 import Paths_hie_bios
+import Data.Void (Void)
+import Data.Function
 
 ----------------------------------------------------------------
 
 progVersion :: String
 progVersion = "hie-bios version " ++ showVersion version ++ " compiled by GHC " ++ Gap.ghcVersion ++ "\n"
 
+data UseLoadStyle
+  = UseSingleFile
+  | UseMultiFile
+
+data Cli = Cli
+  { logLevel :: Maybe L.Severity
+  , biosCommand :: Command
+  }
+
 data Command
   = Check { checkTargetFiles :: [FilePath] }
   | Flags { flagTargetFiles :: [FilePath] }
-  | Debug { debugComponents :: FilePath }
+  | Debug { debugUseMultiLoadStyle :: UseLoadStyle, debugComponents :: [FilePath] }
   | ConfigInfo { configFiles :: [FilePath] }
   | CradleInfo { cradleFiles :: [FilePath] }
   | Root
   | Version
 
 
-filepathParser :: Parser [FilePath]
-filepathParser = some (argument str ( metavar "TARGET_FILES..."))
+filepathParser :: Parser FilePath
+filepathParser = argument str ( metavar "TARGET_FILES...")
 
-progInfo :: ParserInfo Command
-progInfo = info (progParser <**> helper)
+progInfo :: ParserInfo Cli
+progInfo = info (cliParser <**> helper)
   ( fullDesc
   <> progDesc "hie-bios is the way to specify how haskell-language-server and ghcide set up a GHC API session.\
               \Delivers the full set of flags to pass to GHC in order to build the project."
   <> header progVersion
   <> footer "You can report issues/contribute at https://github.com/mpickering/hie-bios")
 
+cliParser :: Parser Cli
+cliParser = Cli
+  <$> optional sevParser
+  <*> progParser
+
+sevParser :: Parser L.Severity
+sevParser =
+  flag' L.Debug (short 'v')
+
 progParser :: Parser Command
-progParser = subparser
-    (command "check" (info (Check <$> filepathParser) (progDesc "Try to load modules into the GHC API."))
-    <> command "flags" (info (Flags <$> filepathParser) (progDesc "Print out the options that hie-bios thinks you will need to load a file."))
-    <> command "debug" (info (Debug <$> argument str ( metavar "TARGET_FILES...")) (progDesc "Print out the options that hie-bios thinks you will need to load a file."))
-    <> command "config" (info (ConfigInfo <$> filepathParser) (progDesc "Print out the cradle config."))
-    <> command "cradle" (info (CradleInfo <$> filepathParser) (progDesc "."))
+progParser = hsubparser
+    (command "check" (info (Check <$> some filepathParser) (progDesc "Try to load modules into the GHC API."))
+    <> command "flags" (info (Flags <$> some filepathParser) (progDesc "Print out the options that hie-bios thinks you will need to load a file."))
+    <> command "debug" (info (Debug <$> loadStyleParser <*> many filepathParser) (progDesc "Print out the options that hie-bios thinks you will need to load a file."))
+    <> command "config" (info (ConfigInfo <$> some filepathParser) (progDesc "Print out the cradle config location."))
+    <> command "cradle" (info (CradleInfo <$> some filepathParser) (progDesc "Print out only the cradle type."))
     <> command "root" (info (pure Root) (progDesc "Display the path towards the selected hie.yaml."))
     <> command "version" (info (pure Version) (progDesc "Print version and exit."))
     )
 
+loadStyleParser :: Parser UseLoadStyle
+loadStyleParser =
+  flag UseSingleFile UseMultiFile (long "multi" <> help "Load all targets in bulk if supported")
 
 ----------------------------------------------------------------
 
@@ -63,11 +86,15 @@ main :: IO ()
 main = do
     hSetEncoding stdout utf8
     cwd <- getCurrentDirectory
-    cmd <- execParser progInfo
+    cli <- execParser progInfo
     let
       printLog (L.WithSeverity l sev) = "[" ++ show sev ++ "] " ++ show (pretty l)
       logger :: forall a . Pretty a => L.LogAction IO (L.WithSeverity a)
-      logger = L.cmap printLog L.logStringStderr
+      logger = L.logStringStderr
+        & L.cmap printLog
+        & L.cfilter (\msg -> case logLevel cli of
+            Nothing -> False
+            Just lvl -> L.getSeverity msg >= lvl )
 
     cradle <-
         -- find cradle does a takeDirectory on the argument, so make it into a file
@@ -75,11 +102,11 @@ main = do
           Just yaml -> loadCradle logger yaml
           Nothing -> loadImplicitCradle logger (cwd </> "File.hs")
 
-    res <- case cmd of
+    res <- case biosCommand cli of
       Check targetFiles -> checkSyntax logger cradle targetFiles
-      Debug files -> case files of
-        [] -> debugInfo (cradleRootDir cradle) cradle
-        fp -> debugInfo fp cradle
+      Debug useMultiStyle files -> do
+        absFiles <- traverse makeAbsolute files
+        debugFiles absFiles useMultiStyle cradle
       Flags files -> case files of
         -- TODO force optparse to acquire one
         [] -> error "too few arguments"
@@ -102,3 +129,16 @@ main = do
       Root    -> rootInfo cradle
       Version -> return progVersion
     putStr res
+
+debugFiles :: [FilePath] -> UseLoadStyle -> Cradle Void -> IO String
+debugFiles fps useLoadStyle cradle = case useLoadStyle of
+  UseSingleFile -> debugSingle
+  UseMultiFile -> debugBulk
+  where
+    debugSingle = case fps of
+      [] -> debugInfo (cradleRootDir cradle) LoadFile cradle
+      _ -> concat <$> traverse (\fp -> debugInfo fp LoadFile cradle) fps
+
+    debugBulk = case fps of
+      [] -> debugInfo (cradleRootDir cradle) (LoadWithContext []) cradle
+      fp:otherFps -> debugInfo fp (LoadWithContext otherFps) cradle

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -26,11 +26,12 @@ import System.Directory
 -- Otherwise, shows the error message and exit-code.
 debugInfo :: Show a
           => FilePath
+          -> LoadStyle
           -> Cradle a
           -> IO String
-debugInfo fp cradle = unlines <$> do
+debugInfo fp loadStyle cradle = unlines <$> do
     let logger = cradleLogger cradle
-    res <- getCompilerOptions fp LoadFile cradle
+    res <- getCompilerOptions fp loadStyle cradle
     canonFp <- canonicalizePath fp
     conf <- findConfig canonFp
     crdl <- findCradle' logger canonFp


### PR DESCRIPTION
Add verbosity flag: `-v` to set the verbosity to `Debug` from the cli.

Allow to toggle the `--multi` mode to load files using `LoadWithContext` load style.
Eases debugging via `hie-bios`.